### PR TITLE
HTTP/2 Multipart message handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -411,6 +411,11 @@
         "trim-right": "1.0.1"
       },
       "dependencies": {
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -4361,6 +4366,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
+    "get-prop": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/get-prop/-/get-prop-0.0.10.tgz",
+      "integrity": "sha1-p2tANdFw3XKKZkVpVbyBkjZzCNI="
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -4811,6 +4821,24 @@
         }
       }
     },
+    "http-message-parser": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/http-message-parser/-/http-message-parser-0.0.22.tgz",
+      "integrity": "sha1-/xoNnaEDAF49NuZltfAwGjUX9Ko=",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "get-prop": "0.0.10",
+        "minimist": "1.2.0",
+        "stream-buffers": "3.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
     "http-parser-js": {
       "version": "0.4.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
@@ -4898,6 +4926,11 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+    },
+    "immutable": {
+      "version": "4.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.9.tgz",
+      "integrity": "sha512-uw4u9Jy3G2Y1qkIFtEGy9NgJxFJT1l3HKgeSFHfrvy91T8W54cJoQ+qK3fTwhil8XkEHuc2S+MI+fbD0vKObDA=="
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -5765,11 +5798,6 @@
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         }
       }
-    },
-    "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-loader": {
       "version": "0.5.7",
@@ -9316,6 +9344,11 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.4"
       }
+    },
+    "stream-buffers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.1.tgz",
+      "integrity": "sha1-aKOMX6re3tef95mI02jj+xMl7wY="
     },
     "stream-http": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "http-message-parser": "0.0.22",
+    "immutable": "^4.0.0-rc.9",
     "material-ui": "^0.20.0",
     "react": "^16.2.0",
     "react-chat-ui": "^0.3.0",

--- a/src/SpeakDirectiveParser.js
+++ b/src/SpeakDirectiveParser.js
@@ -1,0 +1,52 @@
+const httpMessageParser = require("http-message-parser");
+const { hasIn } = require("immutable");
+
+import IllegalArgumentError from "./errors/IllegalArgumentError";
+
+/**
+ * This method parses the multi-part AVS responses and extracts the
+ * string representing Alexa's response. It strips away other information
+ * like binary audio data, ssml tags etc.
+ *
+ * @param {String} alexaRawResponse The multi-part response from AVS. This
+ * should not be empty or undefined.
+ */
+export function extractAlexaTextResponse(alexaRawResponse) {
+  if (!alexaRawResponse) {
+    throw new IllegalArgumentError(
+      "The response to be parsed cannot be empty. Input: " + alexaRawResponse
+    );
+  }
+
+  const parsedResponse = httpMessageParser(alexaRawResponse);
+  if (
+    !parsedResponse ||
+    !parsedResponse.multipart ||
+    !parsedResponse.multipart[0].body ||
+    parsedResponse.multipart[0].body.length == 0
+  ) {
+    throw new IllegalArgumentError(
+      "Given response is not a valid multi-part message. Input: " +
+        alexaRawResponse
+    );
+  }
+
+  const avsDirectiveBuffer = parsedResponse.multipart[0].body;
+  let avsDirective;
+  try {
+    avsDirective = JSON.parse(avsDirectiveBuffer);
+  } catch (e) {
+    throw new IllegalArgumentError(
+      "Given directive couldn't be parsed to a JSON object. Input: " +
+        avsDirectiveBuffer.toString()
+    );
+  }
+
+  if (!hasIn(avsDirective, ["directive", "payload", "caption"]))
+    throw new IllegalArgumentError(
+      "Given directive doesn't contain the expected path directive.payload.caption. Input: " +
+        avsDirective
+    );
+
+  return avsDirective.directive.payload.caption;
+}

--- a/src/SpeakDirectiveParser.test.js
+++ b/src/SpeakDirectiveParser.test.js
@@ -1,0 +1,75 @@
+import { extractAlexaTextResponse } from "./SpeakDirectiveParser";
+import IllegalArgumentError from "./errors/IllegalArgumentError";
+
+import testData from "./test-data/multipart-response-test-data";
+
+it("throws an error if an empty string is passed as input", () => {
+  const input = "";
+  testIllegalArgumentHandling(input);
+});
+
+it("throws an error if undefined is passed as input", () => {
+  let input;
+  testIllegalArgumentHandling(input);
+});
+
+it("handles the invalid case where the multi-part message has only one part.", () => {
+  testIllegalArgumentHandling(testData.multi_part_with_just_one_part.rawData);
+});
+
+it("handles the invalid case where the multi-part message has no body in the first part.", () => {
+  testIllegalArgumentHandling(testData.multi_part_with_no_body.rawData);
+});
+
+it("handles the invalid case where the directive in the AVS response is not a well formatted json.", () => {
+  testIllegalArgumentHandling(testData.directive_not_valid_json.rawData);
+});
+
+it("handles the invalid case where the directive in the AVS response is well formatted but doesn't contain the 'directive' key.", () => {
+  testIllegalArgumentHandling(
+    testData.directive_key_doesnt_exist_in_avs_directive.rawData
+  );
+});
+
+it("handles the invalid case where the directive in the AVS response is well formatted but doesn't contain the 'payload' key.", () => {
+  testIllegalArgumentHandling(
+    testData.payload_key_doesnt_exist_in_avs_directive.rawData
+  );
+});
+
+it("handles the invalid case where the directive in the AVS response is well formatted but doesn't contain the 'caption' key.", () => {
+  testIllegalArgumentHandling(
+    testData.caption_key_doesnt_exist_in_avs_directive.rawData
+  );
+});
+
+it("handles the case where the multi-part message has three parts (because, the happy case is two parts)", () => {
+  const testObject = testData.multi_part_with_just_three_parts;
+
+  const alexaTextResponse = extractAlexaTextResponse(testObject.rawData);
+  expect(alexaTextResponse).toEqual(testObject.alexaResponse);
+});
+
+it("extracts Alexa's response in the happy case", () => {
+  const testObject = testData.happy_case;
+
+  const alexaTextResponse = extractAlexaTextResponse(testObject.rawData);
+  expect(alexaTextResponse).toEqual(testObject.alexaResponse);
+});
+
+it("handles gracefully when Alexa doesn't say anything in response. For ex, when user says 'stop'", () => {
+  const testObject = testData.happy_case_when_alexa_chooses_to_say_nothing;
+
+  const alexaTextResponse = extractAlexaTextResponse(testObject.rawData);
+  expect(alexaTextResponse).toEqual(testObject.alexaResponse);
+});
+
+/**
+ * Verifies that the given input results in an {IllegalArgumentError} when parsed.
+ * @param {String} input The multi part response string that needs to be parsed.
+ */
+const testIllegalArgumentHandling = input => {
+  expect(() => {
+    extractAlexaTextResponse(input);
+  }).toThrow(IllegalArgumentError);
+};

--- a/src/errors/IllegalArgumentError.js
+++ b/src/errors/IllegalArgumentError.js
@@ -1,0 +1,9 @@
+class IllegalArgumentError extends Error {
+  constructor(message) {
+    super(message);
+    this.message = message;
+    this.name = "IllegalArgumentError";
+  }
+}
+
+export default IllegalArgumentError;

--- a/src/test-data/multipart-response-test-data.js
+++ b/src/test-data/multipart-response-test-data.js
@@ -1,0 +1,170 @@
+// Invalid case where multi-part message has just one part. This should never happen in real world.
+{
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"caption","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">caption</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+`;
+
+  exports.multi_part_with_just_one_part = {
+    rawData: rawData
+  };
+}
+
+// Invalid case where multi-part message is well formatted but there is no body in the first part.
+{
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.multi_part_with_no_body = {
+    rawData: rawData
+  };
+}
+
+// Invalid case where the directive in the first part of the message is not well formatted JSON.
+{
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{key: "value", invalidJson: []}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.directive_not_valid_json = {
+    rawData: rawData
+  };
+}
+
+// Invalid case where the AVS directive is well formatted but doesn't contain the 'directive' key.
+{
+  const anyKeyThatIsNot_directive = "notDirective";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"${anyKeyThatIsNot_directive}":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"caption","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">caption</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.directive_key_doesnt_exist_in_avs_directive = {
+    rawData: rawData
+  };
+}
+
+// Invalid case where the AVS directive is well formatted but doesn't contain the 'payload' key.
+{
+  const anyKeyThatIsNot_payload = "notPayload";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"${anyKeyThatIsNot_payload}":{"caption":"caption","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">caption</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.payload_key_doesnt_exist_in_avs_directive = {
+    rawData: rawData
+  };
+}
+
+// Invalid case where the AVS directive is well formatted but doesn't contain the 'caption' key.
+{
+  const anyKeyThatIsNot_caption = "notCaption";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"${anyKeyThatIsNot_caption}":"caption","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">caption</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.caption_key_doesnt_exist_in_avs_directive = {
+    rawData: rawData
+  };
+}
+
+// A multi-part message with three parts. Each of the parts is valid.
+// Important to test this because usually multi-part messages from AVS have two parts but sometimes more.
+{
+  const alexaResponse = "alexa success response";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"${alexaResponse}","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">${alexaResponse}</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-part-of-multi-part-message
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+third-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.multi_part_with_just_three_parts = {
+    rawData: rawData,
+    alexaResponse: alexaResponse
+  };
+}
+
+// Happy case multi-part message
+{
+  const alexaResponse = "alexa success response";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"${alexaResponse}","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">${alexaResponse}</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.happy_case = {
+    rawData: rawData,
+    alexaResponse: alexaResponse
+  };
+}
+
+// Happy case where Alexa chooses to remain silent. For ex, when the user says 'shutup'.
+{
+  const alexaResponse = "";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"c7f315f3-6de6-40c1-807e-8d69ef41d78e"},"payload":{"caption":"${alexaResponse}","url":"cid:GlobalDomain_ActionableAbandon_2b259d35-1caf-432b-ab63-009447af88e6_545084105","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Alexa:Notification#ACRI#GlobalDomain_ActionableAbandon_2b259d35-1caf-432b-ab63-009447af88e6","ssml":"<speak><prosody volume=\"x-loud\"><audio src=\"system_state_active_end.wav\"/></prosody><metadata><promptMetadata><promptId>Error.NLU.Abandoned</promptId><namespace>Platform</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>e04169f9-7a10-4705-8714-8a853817915a</variant><condition/><weight>1</weight><stageVersion>Adm-20140919_230517-32</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.happy_case_when_alexa_chooses_to_say_nothing = {
+    rawData: rawData,
+    alexaResponse: alexaResponse
+  };
+}


### PR DESCRIPTION
AVS returns HTTP/2 Multipart messages to it clients. See https://developer.amazon.com/docs/alexa-voice-service/structure-http2-request.html for more details on the exact structure.

Added a parser that takes the multi-part reponse and extracts the 'caption' which represents the actual content that should be displayed to the user as Alexa's response.

The rest of the message contains audio bytes of the same response, SSML tagsetc., all of which gets dropped.

We are using https://github.com/miguelmota/http-message-parser/ to do the parsing.

Unit tests added.

Note: http-message-parser has a bug in the latest version and so package.json is configured to not use the latest version of this package but use 0.0.22.
A bug has been filed against the developer at https://github.com/miguelmota/http-message-parser/issues/4