### PR TITLE
Preliminary integration of ChatWindow with AVSGateway.

### DIFF
--- a/src/AVSGateway.js
+++ b/src/AVSGateway.js
@@ -19,7 +19,7 @@ Content-Type: application/json; charset=UTF-8
 
 // TODO: Once the region setting is made configurable by the user, the URLS
 // need to ge generated as against hard coded.
-const EVENTS_URL = urls.NA + paths.EVENTS;
+export const EVENTS_URL = urls.NA + paths.EVENTS;
 
 // Default error repsonse if we encounter any unexpected errors.
 const ERROR_MESSAGE = cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR);
@@ -27,7 +27,7 @@ const ERROR_MESSAGE = cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR);
 /**
  * Manages interactions with AVS
  */
-class AVSGateway {
+export default class AVSGateway {
   /**
    * Sends the TextMessage event to AVS and extracts Alexa's response.
    *
@@ -137,8 +137,3 @@ class AVSGateway {
     };
   }
 }
-
-module.exports = {
-  AVSGateway: AVSGateway,
-  EVENTS_URL: EVENTS_URL
-};

--- a/src/AVSGateway.test.js
+++ b/src/AVSGateway.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { AVSGateway, EVENTS_URL } from "./AVSGateway";
+import AVSGateway from "./AVSGateway";
+import { EVENTS_URL } from "./AVSGateway";
 import IllegalArgumentError from "./errors/IllegalArgumentError";
 
 import { cannedErrorResponses, customErrorCodes } from "./CannedErrorResponses";

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,10 +1,12 @@
 import React from "react";
-import {shallow, mount} from "enzyme";
+import { shallow, mount } from "enzyme";
 import App from "./App";
 
 let app;
 let appInstance;
 let originalState;
+
+jest.mock("./AVSGateway");
 
 beforeEach(() => {
   app = shallow(<App />);
@@ -24,34 +26,45 @@ it("snapshot testing that it renders correctly", () => {
 it("should not change state when authorization response (implicit grant) is not defined", () => {
   global.console = {
     log: jest.fn()
-  }
+  };
   appInstance.handleAuthenticationInfoUpdate();
   expect(appInstance.state).toEqual(originalState);
-  expect(global.console.log).toHaveBeenCalledWith("Encountered an error on login: undefined");
+  expect(global.console.log).toHaveBeenCalledWith(
+    "Encountered an error on login: undefined"
+  );
 });
 
 it("should not change state when authorization fails (implicit grant)", () => {
   global.console = {
     log: jest.fn()
-  }
+  };
   const util = require("util");
   const response = {
     error: "some_error_code",
     error_description: "description about error as string",
-    state: {page: "http://somePage"}
-  }
+    state: { page: "http://somePage" }
+  };
   appInstance.handleAuthenticationInfoUpdate(response);
   expect(appInstance.state).toEqual(originalState);
   // Verify error message has been logged to console
-  expect(global.console.log)
-    .toHaveBeenCalledWith("Encountered an error on login: " + util.inspect(response, {showHidden: true, depth: null}))
+  expect(global.console.log).toHaveBeenCalledWith(
+    "Encountered an error on login: " +
+      util.inspect(response, { showHidden: true, depth: null })
+  );
 });
 
 it("should change state when authorization response (implicit grant) is defined", () => {
-  const authResponse = {access_token: "some_access_token", expires_in: 30, state: "user_defined_state"};
+  const authResponse = {
+    access_token: "some_access_token",
+    expires_in: 30,
+    state: "user_defined_state"
+  };
   appInstance.handleAuthenticationInfoUpdate(authResponse);
   const finalState = {
-    authenticationInfo: {access_token: authResponse.access_token, expires_in: authResponse.expires_in}
+    authenticationInfo: {
+      access_token: authResponse.access_token,
+      expires_in: authResponse.expires_in
+    }
   };
   expect(appInstance.state).toEqual(finalState);
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -6,8 +6,6 @@ let app;
 let appInstance;
 let originalState;
 
-jest.mock("./AVSGateway");
-
 beforeEach(() => {
   app = shallow(<App />);
   appInstance = app.instance();

--- a/src/Body.test.js
+++ b/src/Body.test.js
@@ -2,8 +2,6 @@ import React from "react";
 import { mount } from "enzyme";
 import Body from "./Body";
 
-jest.mock("./AVSGateway");
-
 it("renders Body without crashing", () => {
   mount(<Body />);
 });

--- a/src/Body.test.js
+++ b/src/Body.test.js
@@ -1,6 +1,8 @@
 import React from "react";
-import {mount} from "enzyme";
+import { mount } from "enzyme";
 import Body from "./Body";
+
+jest.mock("./AVSGateway");
 
 it("renders Body without crashing", () => {
   mount(<Body />);

--- a/src/CannedErrorResponses.js
+++ b/src/CannedErrorResponses.js
@@ -17,7 +17,8 @@ const cannedErrorResponses = Map({
     "a canned response for INTERNAL_SERVICE_EXCEPTION",
   "N/A": "a canned response for N/A Exception",
 
-  UNKNOWN_ERROR: "a canned response for UNKNOWN_ERROR"
+  UNKNOWN_ERROR:
+    "a canned response for UNKNOWN_ERROR. This shouldn't ever happen. Don't show it as an Alexa bubble."
 });
 
 const customErrorCodes = Object.freeze({

--- a/src/ChatWindow.js
+++ b/src/ChatWindow.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import { ChatFeed, Message } from "react-chat-ui";
 import ContainerDimensions from "react-container-dimensions";
 
-import AVSGateway from "./AVSGateway";
 import { cannedErrorResponses, customErrorCodes } from "./CannedErrorResponses";
 
 import UserRequestToAlexaForm from "./UserRequestToAlexaForm";
@@ -10,6 +9,7 @@ import "./ChatWindow.css";
 
 import { users, userIds } from "./ConversingUsers";
 
+import AVSGateway from "./AVSGateway";
 const avs = new AVSGateway();
 
 class ChatWindow extends Component {
@@ -78,9 +78,9 @@ class ChatWindow extends Component {
 
     // TODO: Send the actual access token once we integrate ChatWindow with the
     // state object that contains the real access token. For now, not passing
-    // an access token which means AVS will throw an error.
+    // an access_token which means AVS will throw an error.
     avs
-      .sendTextMessageEvent(userRequestToAlexa /*, "access token"*/)
+      .sendTextMessageEvent(userRequestToAlexa /*, "access_token"*/)
       .then(response => {
         this.pushMessage(userIds.ALEXA, response);
       })

--- a/src/ChatWindow.js
+++ b/src/ChatWindow.js
@@ -2,10 +2,15 @@ import React, { Component } from "react";
 import { ChatFeed, Message } from "react-chat-ui";
 import ContainerDimensions from "react-container-dimensions";
 
+import AVSGateway from "./AVSGateway";
+import { cannedErrorResponses, customErrorCodes } from "./CannedErrorResponses";
+
 import UserRequestToAlexaForm from "./UserRequestToAlexaForm";
 import "./ChatWindow.css";
 
 import { users, userIds } from "./ConversingUsers";
+
+const avs = new AVSGateway();
 
 class ChatWindow extends Component {
   constructor() {
@@ -70,6 +75,23 @@ class ChatWindow extends Component {
     }
     this.pushMessage(this.state.curr_user_id, userRequestToAlexa);
     this.setState({ userRequestToAlexa: "" });
+
+    // TODO: Send the actual access token once we integrate ChatWindow with the
+    // state object that contains the real access token. For now, not passing
+    // an access token which means AVS will throw an error.
+    avs
+      .sendTextMessageEvent(userRequestToAlexa /*, "access token"*/)
+      .then(response => {
+        this.pushMessage(userIds.ALEXA, response);
+      })
+      .catch(error => {
+        // TODO: Don't show this as an Alexa bubble. It also doesn't make to show it as a user bubble.
+        // Need to find a way to represent this error on the UI.
+        this.pushMessage(
+          userIds.ALEXA,
+          cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR)
+        );
+      });
 
     return true;
   }

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -195,8 +195,10 @@ it("handles the user's input as they are typing their request (before submission
 });
 
 /**
- * Verifies that the given input results in an {IllegalArgumentError} when parsed.
- * @param {String} input The multi part response string that needs to be parsed.
+ * Helper method to test the interaction with Alexa. Will simulate a user request and
+ * verify that the expected messages are populated into the state.
+ * @param {Message} expectedAlexaResponse The expected response from Alexa to be verified
+ * against.
  */
 const testOnUserRequestToAlexaSubmitHandling = (
   expectedAlexaResponse,

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -3,6 +3,12 @@ import { shallow, mount } from "enzyme";
 
 import { ChatFeed, Message } from "react-chat-ui";
 import ChatWindow from "./ChatWindow";
+import { cannedErrorResponses, customErrorCodes } from "./CannedErrorResponses";
+
+import {
+  mockSendTextMessageEventFunction,
+  mockAlexaSuccessResponse
+} from "./AVSGateway";
 
 import { users, userIds } from "./ConversingUsers";
 
@@ -16,12 +22,16 @@ const setHeightElement = function(height) {
   });
 };
 
+jest.mock("./AVSGateway");
+
 let chatWindow;
 let chatWindowInstance;
 let originalState;
 let preventDefaultSpy;
 
 beforeEach(() => {
+  mockSendTextMessageEventFunction.mockClear();
+
   preventDefaultSpy = jest.fn();
   chatWindow = shallow(<ChatWindow />);
   chatWindowInstance = chatWindow.instance();
@@ -107,43 +117,35 @@ it("handles gracefully when pushMessage is called with an empty or null message"
   expect(finalState).toEqual(originalState);
 });
 
-it("handles the user's form submission with request to Alexa properly", () => {
-  const chatWindow = mount(<ChatWindow />);
-  const chatWindowInstance = chatWindow.instance();
-  const originalState = JSON.parse(JSON.stringify(chatWindowInstance.state));
-
-  const userRequestToAlexaForm = chatWindow.find("form").get(0);
-  const numberOfMessagesAlreadyInState = originalState.messages.length;
-
-  const mockuserRequestToAlexa = "mock request";
-  const userId = userIds.YOU;
-  const user = users.get(userId);
-  chatWindowInstance.setState({
-    userRequestToAlexa: mockuserRequestToAlexa,
-    curr_user: userId
+it("handles the user's form submission with request to Alexa and populates the state with the user request and Alexa's response", done => {
+  const alexaId = userIds.ALEXA;
+  const alexa = users.get(alexaId);
+  let expectedAlexaResponse = new Message({
+    id: alexaId,
+    message: mockAlexaSuccessResponse,
+    senderName: alexa.name
   });
 
-  chatWindow
-    .find("form")
-    .simulate("submit", { preventDefault: preventDefaultSpy });
+  testOnUserRequestToAlexaSubmitHandling(expectedAlexaResponse, done);
+});
 
-  // Verify that preventDefault() is being called.
-  expect(preventDefaultSpy.mock.calls.length).toBe(1);
-
-  const finalState = chatWindowInstance.state;
-
-  const expectedMessage = new Message({
-    id: userId,
-    message: mockuserRequestToAlexa,
-    senderName: user.name
-  });
-  const finalMessages = finalState.messages;
-  expect(finalMessages.length).toBe(numberOfMessagesAlreadyInState + 1);
-  expect(finalMessages[numberOfMessagesAlreadyInState]).toEqual(
-    expectedMessage
+it("handles the case when AVS throws an error in response to a user request. We should populate the state with the user request and a canned response.", done => {
+  // mock the AVSGateway to throw an error.
+  mockSendTextMessageEventFunction.mockImplementation(() =>
+    Promise.reject(
+      new Error(cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR))
+    )
   );
 
-  expect(chatWindowInstance.state.userRequestToAlexa).toEqual("");
+  const alexaId = userIds.ALEXA;
+  const alexa = users.get(alexaId);
+  let expectedAlexaResponse = new Message({
+    id: alexaId,
+    message: cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR),
+    senderName: alexa.name
+  });
+
+  testOnUserRequestToAlexaSubmitHandling(expectedAlexaResponse, done);
 });
 
 it("handles gracefully when the input form is submitted with a null or empty request string", () => {
@@ -191,3 +193,60 @@ it("handles the user's input as they are typing their request (before submission
   expect(preventDefaultSpy.mock.calls.length).toBe(1);
   expect(finalUserRequestToAlexa).toEqual(expectedUserRequestToAlexa);
 });
+
+/**
+ * Verifies that the given input results in an {IllegalArgumentError} when parsed.
+ * @param {String} input The multi part response string that needs to be parsed.
+ */
+const testOnUserRequestToAlexaSubmitHandling = (
+  expectedAlexaResponse,
+  done
+) => {
+  const chatWindow = mount(<ChatWindow />);
+  const chatWindowInstance = chatWindow.instance();
+  const originalState = JSON.parse(JSON.stringify(chatWindowInstance.state));
+
+  const userRequestToAlexaForm = chatWindow.find("form").get(0);
+  const numberOfMessagesAlreadyInState = originalState.messages.length;
+
+  const mockuserRequestToAlexa = "mock request";
+  const userId = userIds.YOU;
+  const user = users.get(userId);
+  chatWindowInstance.setState({
+    userRequestToAlexa: mockuserRequestToAlexa,
+    curr_user: userId
+  });
+
+  chatWindow
+    .find("form")
+    .simulate("submit", { preventDefault: preventDefaultSpy });
+
+  expect(preventDefaultSpy.mock.calls.length).toBe(1);
+
+  expect(mockSendTextMessageEventFunction).toHaveBeenCalledTimes(1);
+  expect(mockSendTextMessageEventFunction).toHaveBeenCalledWith(
+    mockuserRequestToAlexa
+  );
+
+  let expectedUserMessage = new Message({
+    id: userId,
+    message: mockuserRequestToAlexa,
+    senderName: user.name
+  });
+
+  setImmediate(() => {
+    const finalState = chatWindowInstance.state;
+    const finalMessages = finalState.messages;
+
+    expect(finalMessages.length).toBe(numberOfMessagesAlreadyInState + 2);
+    expect(finalMessages[finalMessages.length - 2]).toEqual(
+      expectedUserMessage
+    );
+    expect(finalMessages[finalMessages.length - 1]).toEqual(
+      expectedAlexaResponse
+    );
+
+    expect(chatWindowInstance.state.userRequestToAlexa).toEqual("");
+    done();
+  });
+};

--- a/src/SpeakDirectiveParser.js
+++ b/src/SpeakDirectiveParser.js
@@ -1,8 +1,8 @@
+import IllegalArgumentError from "./errors/IllegalArgumentError";
+
 const httpMessageParser = require("http-message-parser");
 const { hasIn } = require("immutable");
 const util = require("util");
-
-import IllegalArgumentError from "./errors/IllegalArgumentError";
 
 /**
  * This method parses the multi-part AVS responses and extracts the

--- a/src/UserRequestToAlexaForm.test.js
+++ b/src/UserRequestToAlexaForm.test.js
@@ -1,11 +1,13 @@
 import React from "react";
-import {mount} from "enzyme";
+import { mount } from "enzyme";
 
 import ChatWindow from "./ChatWindow";
 import UserRequestToAlexaForm from "./UserRequestToAlexaForm";
 import TextField from "material-ui/TextField";
 
 const DEFAULT_PLACEHOLDER_VALUE = require("./Constants");
+
+jest.mock("./AVSGateway");
 
 it("renders UserRequestToAlexaForm without crashing", () => {
   mount(<UserRequestToAlexaForm />);

--- a/src/UserRequestToAlexaForm.test.js
+++ b/src/UserRequestToAlexaForm.test.js
@@ -7,8 +7,6 @@ import TextField from "material-ui/TextField";
 
 const DEFAULT_PLACEHOLDER_VALUE = require("./Constants");
 
-jest.mock("./AVSGateway");
-
 it("renders UserRequestToAlexaForm without crashing", () => {
   mount(<UserRequestToAlexaForm />);
 });

--- a/src/__mocks__/AVSGateway.js
+++ b/src/__mocks__/AVSGateway.js
@@ -1,0 +1,12 @@
+export const mockAlexaSuccessResponse = "mock alexa success response";
+
+// Mock implementation that always resolves to a successful response from AVS.
+export const mockSendTextMessageEventFunction = jest.fn(() =>
+  Promise.resolve(mockAlexaSuccessResponse)
+);
+
+const mockAVSGateway = jest.fn().mockImplementation(() => {
+  return { sendTextMessageEvent: mockSendTextMessageEventFunction };
+});
+
+export default mockAVSGateway;


### PR DESCRIPTION
We still haven't plumbed through the real access tokens and so for now, the
calls to AVSGateway will always return a 403 and as a result, Alexa
will effectively respond with an error message all the time.

Having said that, this is a good step forward because it basically
makes the chatwindow interactive for the first time. User can type
something and get a response from Alexa, even though it is just an
error message each time.

In a later commit, we just need to plumb the access token through.

There was a different commit that made some formatting related settings
changes and as a result, this commit picked up some format changes.