### PR TITLE
Refactor users to align with ChatWindow expectations.

### DIFF
--- a/src/ConversingUsers.js
+++ b/src/ConversingUsers.js
@@ -1,15 +1,13 @@
 const { Map } = require("immutable");
 
 const userIds = Object.freeze({
-  YOU: "user_id_of_client_interacting_with_alexa",
-  ALEXA: "user_id_of_alexa",
-  MEDIATOR: "user_id_of_mediator"
+  YOU: 0,
+  ALEXA: 1
 });
 
 const users = Map([
   [userIds.YOU, { name: "You" }],
-  [userIds.ALEXA, { name: "Alexa" }],
-  [userIds.MEDIATOR, { name: "Mediator" }]
+  [userIds.ALEXA, { name: "Alexa" }]
 ]);
 
 module.exports = {


### PR DESCRIPTION
ChatWindow doesn't support an arbitrary number of users and the userIds cannot

be random strings. It has to be two users and their Ids should be 0 and 1.

Refactored the ConversingUsers to align with ChatWindow's expectations.