### PR TITLE
Pass real access token to AVSGateway.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ class App extends Component {
             this.handleAuthenticationInfoUpdate(authResponse)
           }
         />
-        <Body />
+        <Body authenticationInfo={this.state.authenticationInfo} />
         <Footer />
       </div>
     );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -21,6 +21,18 @@ it("snapshot testing that it renders correctly", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it("verifies that authenticationInfo is passed to Body component", () => {
+  const wrapper = mount(<App />);
+  const originalAuthenticationInfo = wrapper.instance().state
+    .authenticationInfo;
+
+  // Verify that Body recieves authenticationInfo property
+  const authenticationInfoProp = wrapper
+    .find("Body")
+    .prop("authenticationInfo");
+  expect(authenticationInfoProp).toBe(originalAuthenticationInfo);
+});
+
 it("should not change state when authorization response (implicit grant) is not defined", () => {
   global.console = {
     log: jest.fn()

--- a/src/Body.js
+++ b/src/Body.js
@@ -7,7 +7,7 @@ export default class Body extends Component {
   render() {
     return [
       <MuiThemeProvider key="muiThemeProvider">
-        <ChatWindow />
+        <ChatWindow authenticationInfo={this.props.authenticationInfo} />
       </MuiThemeProvider>,
 
       <RightPanel key="rightPanel" />

--- a/src/Body.test.js
+++ b/src/Body.test.js
@@ -12,3 +12,14 @@ it("renders correctly (snapshot testing)", () => {
 
   wrapper.unmount();
 });
+
+it("verifies that authenticationInfo is passed to ChatWindow component", () => {
+  const mockAuthenticationInfo = {};
+  const body = mount(<Body authenticationInfo={mockAuthenticationInfo} />);
+
+  // Verify that ChatWindow recieves authenticationInfo property
+  const authenticationInfoProp = body
+    .find("ChatWindow")
+    .prop("authenticationInfo");
+  expect(authenticationInfoProp).toBe(mockAuthenticationInfo);
+});

--- a/src/ChatWindow.js
+++ b/src/ChatWindow.js
@@ -11,6 +11,7 @@ import { users, userIds } from "./ConversingUsers";
 
 import AVSGateway from "./AVSGateway";
 const avs = new AVSGateway();
+const { getIn } = require("immutable");
 
 class ChatWindow extends Component {
   constructor() {
@@ -76,11 +77,9 @@ class ChatWindow extends Component {
     this.pushMessage(this.state.curr_user_id, userRequestToAlexa);
     this.setState({ userRequestToAlexa: "" });
 
-    // TODO: Send the actual access token once we integrate ChatWindow with the
-    // state object that contains the real access token. For now, not passing
-    // an access_token which means AVS will throw an error.
+    const access_token = getIn(this.props.authenticationInfo, ["access_token"]);
     avs
-      .sendTextMessageEvent(userRequestToAlexa /*, "access_token"*/)
+      .sendTextMessageEvent(userRequestToAlexa, access_token)
       .then(response => {
         this.pushMessage(userIds.ALEXA, response);
       })

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -117,7 +117,47 @@ it("handles gracefully when pushMessage is called with an empty or null message"
   expect(finalState).toEqual(originalState);
 });
 
+test("that when a user submits the form, we call AVSGateway with their request even if the access_token is not available.", () => {
+  const authInfoWithMissingAccessToken = { access_token: undefined };
+  let missingAuthInfo;
+  const invalidAuthenticationInfoObjects = [
+    authInfoWithMissingAccessToken,
+    missingAuthInfo
+  ];
+
+  for (let i = 0; i < invalidAuthenticationInfoObjects.length; i++) {
+    const authenticationInfo = invalidAuthenticationInfoObjects[i];
+    const chatWindow = mount(
+      <ChatWindow authenticationInfo={authenticationInfo} />
+    );
+    const chatWindowInstance = chatWindow.instance();
+
+    const userRequestToAlexaForm = chatWindow.find("form").get(0);
+    const numberOfMessagesAlreadyInState = originalState.messages.length;
+
+    const mockuserRequestToAlexa = "mock request";
+    chatWindowInstance.setState({
+      userRequestToAlexa: "mock request",
+      curr_user: users.get(userIds.YOU)
+    });
+
+    chatWindow
+      .find("form")
+      .simulate("submit", { preventDefault: preventDefaultSpy });
+
+    expect(mockSendTextMessageEventFunction).toHaveBeenCalledTimes(1);
+    expect(mockSendTextMessageEventFunction).toHaveBeenCalledWith(
+      mockuserRequestToAlexa,
+      undefined
+    );
+
+    mockSendTextMessageEventFunction.mockClear();
+  }
+});
+
 it("handles the user's form submission with request to Alexa and populates the state with the user request and Alexa's response", done => {
+  const mockAuthenticationInfo = { access_token: "mockAccessToken" };
+
   const alexaId = userIds.ALEXA;
   const alexa = users.get(alexaId);
   let expectedAlexaResponse = new Message({
@@ -126,10 +166,16 @@ it("handles the user's form submission with request to Alexa and populates the s
     senderName: alexa.name
   });
 
-  testOnUserRequestToAlexaSubmitHandling(expectedAlexaResponse, done);
+  testOnUserRequestToAlexaSubmitHandling(
+    mockAuthenticationInfo,
+    expectedAlexaResponse,
+    done
+  );
 });
 
 it("handles the case when AVS throws an error in response to a user request. We should populate the state with the user request and a canned response.", done => {
+  const mockAuthenticationInfo = { access_token: "mockAccessToken" };
+
   // mock the AVSGateway to throw an error.
   mockSendTextMessageEventFunction.mockImplementation(() =>
     Promise.reject(
@@ -145,7 +191,11 @@ it("handles the case when AVS throws an error in response to a user request. We 
     senderName: alexa.name
   });
 
-  testOnUserRequestToAlexaSubmitHandling(expectedAlexaResponse, done);
+  testOnUserRequestToAlexaSubmitHandling(
+    mockAuthenticationInfo,
+    expectedAlexaResponse,
+    done
+  );
 });
 
 it("handles gracefully when the input form is submitted with a null or empty request string", () => {
@@ -201,10 +251,13 @@ it("handles the user's input as they are typing their request (before submission
  * against.
  */
 const testOnUserRequestToAlexaSubmitHandling = (
+  mockAuthenticationInfo,
   expectedAlexaResponse,
   done
 ) => {
-  const chatWindow = mount(<ChatWindow />);
+  const chatWindow = mount(
+    <ChatWindow authenticationInfo={mockAuthenticationInfo} />
+  );
   const chatWindowInstance = chatWindow.instance();
   const originalState = JSON.parse(JSON.stringify(chatWindowInstance.state));
 
@@ -227,7 +280,8 @@ const testOnUserRequestToAlexaSubmitHandling = (
 
   expect(mockSendTextMessageEventFunction).toHaveBeenCalledTimes(1);
   expect(mockSendTextMessageEventFunction).toHaveBeenCalledWith(
-    mockuserRequestToAlexa
+    mockuserRequestToAlexa,
+    mockAuthenticationInfo.access_token
   );
 
   let expectedUserMessage = new Message({

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -43,11 +43,15 @@ exports[`snapshot testing that it renders correctly 1`] = `
         </div>
       </div>
     </Header>
-    <Body>
+    <Body
+      authenticationInfo={Object {}}
+    >
       <MuiThemeProvider
         key="muiThemeProvider"
       >
-        <ChatWindow>
+        <ChatWindow
+          authenticationInfo={Object {}}
+        >
           <div
             id="leftpanel"
           >


### PR DESCRIPTION
Now that the access_token has been plumbed through the state, in this commit we start using it by passing the real access_token to AVSGateway. We have an end-end functioning silent Alexa with this commit.

Note that for now, we blindly pass the access_token regardless of whether or not it is valid and if it is even present. The assumption is that it is either

the 'App' component's responsibility to kick the user back to a login screen whenever the access_token is missing or expired.
OR
AVSGateway's responsibility to notify App to kick the user out whenever it receives a 403 from Alexa or notices a missing access_token.
Said logout mechanism will be implemented in a later commit.