### PR TITLE
Pass real access token to AVSGateway.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.1.tgz",
+      "integrity": "sha512-xwlHq5DXQFRpe+u6hmmNkzYk/3oxxqDp71a/AJMupOQYmxyaBetqrVMqdNlSQfbg7XTJYD8vARjf3Op06OzdtQ==",
       "dev": true
     },
     "abab": {
@@ -1627,7 +1627,7 @@
           "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
           "dev": true,
           "requires": {
-            "@types/node": "9.4.6"
+            "@types/node": "9.6.1"
           }
         }
       }
@@ -6418,9 +6418,9 @@
       }
     },
     "nearley": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.1.tgz",
-      "integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.13.0.tgz",
+      "integrity": "sha512-ioYYogSaZhFlCpRizQgY3UT3G1qFXmHGY/5ozoFE3dMfiCRAeJfh+IPE3/eh9gCZvqLhPCWb4bLt7Bqzo+1mLQ==",
       "dev": true,
       "requires": {
         "nomnom": "1.6.2",
@@ -12907,7 +12907,7 @@
       "dev": true,
       "requires": {
         "lodash.flattendeep": "4.4.0",
-        "nearley": "2.11.1"
+        "nearley": "2.13.0"
       }
     },
     "run-async": {

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ class App extends Component {
             this.handleAuthenticationInfoUpdate(authResponse)
           }
         />
-        <Body />
+        <Body authenticationInfo={this.state.authenticationInfo} />
         <Footer />
       </div>
     );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -18,6 +18,18 @@ it("renders correctly without crashing", () => {
   wrapper.unmount();
 });
 
+it("verifies that authenticationInfo is passed to Body component", () => {
+  const wrapper = shallow(<App />);
+  const originalAuthenticationInfo = wrapper.instance().state
+    .authenticationInfo;
+
+  // Verify that Body recieves authenticationInfo property
+  const authenticationInfoProp = wrapper
+    .find("Body")
+    .prop("authenticationInfo");
+  expect(authenticationInfoProp).toBe(originalAuthenticationInfo);
+});
+
 it("should not change state when authorization response (implicit grant) is not defined", () => {
   global.console = {
     log: jest.fn()
@@ -44,7 +56,7 @@ it("should not change state when authorization fails (implicit grant)", () => {
   // Verify error message has been logged to console
   expect(global.console.log).toHaveBeenCalledWith(
     "Encountered an error on login: " +
-    util.inspect(response, { showHidden: true, depth: null })
+      util.inspect(response, { showHidden: true, depth: null })
   );
 });
 

--- a/src/Body.js
+++ b/src/Body.js
@@ -7,7 +7,7 @@ export default class Body extends Component {
   render() {
     return [
       <MuiThemeProvider key="muiThemeProvider">
-        <ChatWindow />
+        <ChatWindow authenticationInfo={this.props.authenticationInfo} />
       </MuiThemeProvider>,
 
       <RightPanel key="rightPanel" />

--- a/src/Body.test.js
+++ b/src/Body.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import Body from "./Body";
 
 it("renders correctly without crashing", () => {
@@ -7,4 +7,23 @@ it("renders correctly without crashing", () => {
   expect(wrapper).toMatchSnapshot();
 
   wrapper.unmount();
+});
+
+// TODO: We should use shallow here instead of mount. However, because
+// Body is a component that returns an array of elements, enzyme doesn't
+// yet support this feature.
+
+// They fixed it here https://github.com/airbnb/enzyme/commit/6f7f4fbae19050a912c70e6fbfe42c47b0851fe3
+
+// It is not yet released on npm though. Once enzyme version > 3.3.0 is
+// released, we need to fix this test.
+it("verifies that authenticationInfo is passed to ChatWindow component", () => {
+  const mockAuthenticationInfo = {};
+  const body = mount(<Body authenticationInfo={mockAuthenticationInfo} />);
+
+  // Verify that ChatWindow recieves authenticationInfo property
+  const authenticationInfoProp = body
+    .find("ChatWindow")
+    .prop("authenticationInfo");
+  expect(authenticationInfoProp).toBe(mockAuthenticationInfo);
 });

--- a/src/Body.test.js
+++ b/src/Body.test.js
@@ -9,7 +9,7 @@ it("renders correctly without crashing", () => {
   wrapper.unmount();
 });
 
-// TODO: We should use shallow here instead of mount. However, because
+// TODO: We should use shallow or render here instead of mount. However, because
 // Body is a component that returns an array of elements, enzyme doesn't
 // yet support this feature.
 

--- a/src/ChatWindow.js
+++ b/src/ChatWindow.js
@@ -11,6 +11,7 @@ import { users, userIds } from "./ConversingUsers";
 
 import AVSGateway from "./AVSGateway";
 const avs = new AVSGateway();
+const { getIn } = require("immutable");
 
 class ChatWindow extends Component {
   constructor() {
@@ -76,11 +77,9 @@ class ChatWindow extends Component {
     this.pushMessage(this.state.curr_user_id, userRequestToAlexa);
     this.setState({ userRequestToAlexa: "" });
 
-    // TODO: Send the actual access token once we integrate ChatWindow with the
-    // state object that contains the real access token. For now, not passing
-    // an access_token which means AVS will throw an error.
+    const access_token = getIn(this.props.authenticationInfo, ["access_token"]);
     avs
-      .sendTextMessageEvent(userRequestToAlexa /*, "access_token"*/)
+      .sendTextMessageEvent(userRequestToAlexa, access_token)
       .then(response => {
         this.pushMessage(userIds.ALEXA, response);
       })

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -14,7 +14,7 @@ import { users, userIds } from "./ConversingUsers";
 
 const CHATFEED_CONTAINER_HEIGHT = 234;
 const CHATFEED_CONTAINER_HEIGHT_DEFAULT = 0;
-const setHeightElement = function (height) {
+const setHeightElement = function(height) {
   Element.prototype.getBoundingClientRect = jest.fn(() => {
     return {
       height: height
@@ -114,10 +114,14 @@ it("handles gracefully when pushMessage is called with an empty or null message"
 });
 
 test("that when a user submits the form, we call AVSGateway with their request even if the access_token is not available.", () => {
-  const authInfoWithMissingAccessToken = { access_token: undefined };
+  const authInfoWithMissingAccessTokenKey = {
+    a_key_that_is_not_access_token: ""
+  };
+  const authInfoWithMissingAccessTokenValue = { access_token: undefined };
   let missingAuthInfo;
   const invalidAuthenticationInfoObjects = [
-    authInfoWithMissingAccessToken,
+    authInfoWithMissingAccessTokenKey,
+    authInfoWithMissingAccessTokenValue,
     missingAuthInfo
   ];
 
@@ -131,9 +135,9 @@ test("that when a user submits the form, we call AVSGateway with their request e
     const userRequestToAlexaForm = chatWindow.find("form").get(0);
     const numberOfMessagesAlreadyInState = originalState.messages.length;
 
-    const mockuserRequestToAlexa = "mock request";
+    const userRequestToAlexa = "a dummy user request";
     chatWindowInstance.setState({
-      userRequestToAlexa: "mock request",
+      userRequestToAlexa: userRequestToAlexa,
       curr_user: users.get(userIds.YOU)
     });
 
@@ -143,7 +147,7 @@ test("that when a user submits the form, we call AVSGateway with their request e
 
     expect(mockSendTextMessageEventFunction).toHaveBeenCalledTimes(1);
     expect(mockSendTextMessageEventFunction).toHaveBeenCalledWith(
-      mockuserRequestToAlexa,
+      userRequestToAlexa,
       undefined
     );
 
@@ -152,7 +156,7 @@ test("that when a user submits the form, we call AVSGateway with their request e
 });
 
 it("handles the user's form submission with request to Alexa and populates the state with the user request and Alexa's response", done => {
-  const mockAuthenticationInfo = { access_token: "mockAccessToken" };
+  const authenticationInfo = { access_token: "a dummy access token" };
 
   const alexaId = userIds.ALEXA;
   const alexa = users.get(alexaId);
@@ -163,14 +167,14 @@ it("handles the user's form submission with request to Alexa and populates the s
   });
 
   testOnUserRequestToAlexaSubmitHandling(
-    mockAuthenticationInfo,
+    authenticationInfo,
     expectedAlexaResponse,
     done
   );
 });
 
 it("handles the case when AVS throws an error in response to a user request. We should populate the state with the user request and a canned response.", done => {
-  const mockAuthenticationInfo = { access_token: "mockAccessToken" };
+  const authenticationInfo = { access_token: "a dummy access token" };
 
   // mock the AVSGateway to throw an error.
   mockSendTextMessageEventFunction.mockImplementation(() =>
@@ -188,7 +192,7 @@ it("handles the case when AVS throws an error in response to a user request. We 
   });
 
   testOnUserRequestToAlexaSubmitHandling(
-    mockAuthenticationInfo,
+    authenticationInfo,
     expectedAlexaResponse,
     done
   );
@@ -225,12 +229,12 @@ it("handles the user's input as they are typing their request (before submission
     curr_user: 1
   });
 
-  const expectedUserRequestToAlexa = "mock request";
-  const mockEvent = {
+  const expectedUserRequestToAlexa = "a dummy user request";
+  const event = {
     target: { value: expectedUserRequestToAlexa },
     preventDefault: preventDefaultSpy
   };
-  chatWindow.find("UserRequestToAlexaForm").simulate("change", mockEvent);
+  chatWindow.find("UserRequestToAlexaForm").simulate("change", event);
 
   const finalState = chatWindowInstance.state;
   const finalUserRequestToAlexa = finalState.userRequestToAlexa;
@@ -247,12 +251,12 @@ it("handles the user's input as they are typing their request (before submission
  * against.
  */
 const testOnUserRequestToAlexaSubmitHandling = (
-  mockAuthenticationInfo,
+  authenticationInfo,
   expectedAlexaResponse,
   done
 ) => {
   const chatWindow = mount(
-    <ChatWindow authenticationInfo={mockAuthenticationInfo} />
+    <ChatWindow authenticationInfo={authenticationInfo} />
   );
   const chatWindowInstance = chatWindow.instance();
   const originalState = JSON.parse(JSON.stringify(chatWindowInstance.state));
@@ -260,11 +264,11 @@ const testOnUserRequestToAlexaSubmitHandling = (
   const userRequestToAlexaForm = chatWindow.find("form").get(0);
   const numberOfMessagesAlreadyInState = originalState.messages.length;
 
-  const mockuserRequestToAlexa = "mock request";
+  const userRequestToAlexa = "a dummy user request";
   const userId = userIds.YOU;
   const user = users.get(userId);
   chatWindowInstance.setState({
-    userRequestToAlexa: mockuserRequestToAlexa,
+    userRequestToAlexa: userRequestToAlexa,
     curr_user: userId
   });
 
@@ -276,13 +280,13 @@ const testOnUserRequestToAlexaSubmitHandling = (
 
   expect(mockSendTextMessageEventFunction).toHaveBeenCalledTimes(1);
   expect(mockSendTextMessageEventFunction).toHaveBeenCalledWith(
-    mockuserRequestToAlexa,
-    mockAuthenticationInfo.access_token
+    userRequestToAlexa,
+    authenticationInfo.access_token
   );
 
   let expectedUserMessage = new Message({
     id: userId,
-    message: mockuserRequestToAlexa,
+    message: userRequestToAlexa,
     senderName: user.name
   });
 

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -113,7 +113,47 @@ it("handles gracefully when pushMessage is called with an empty or null message"
   expect(finalState).toEqual(originalState);
 });
 
+test("that when a user submits the form, we call AVSGateway with their request even if the access_token is not available.", () => {
+  const authInfoWithMissingAccessToken = { access_token: undefined };
+  let missingAuthInfo;
+  const invalidAuthenticationInfoObjects = [
+    authInfoWithMissingAccessToken,
+    missingAuthInfo
+  ];
+
+  for (let i = 0; i < invalidAuthenticationInfoObjects.length; i++) {
+    const authenticationInfo = invalidAuthenticationInfoObjects[i];
+    const chatWindow = mount(
+      <ChatWindow authenticationInfo={authenticationInfo} />
+    );
+    const chatWindowInstance = chatWindow.instance();
+
+    const userRequestToAlexaForm = chatWindow.find("form").get(0);
+    const numberOfMessagesAlreadyInState = originalState.messages.length;
+
+    const mockuserRequestToAlexa = "mock request";
+    chatWindowInstance.setState({
+      userRequestToAlexa: "mock request",
+      curr_user: users.get(userIds.YOU)
+    });
+
+    chatWindow
+      .find("form")
+      .simulate("submit", { preventDefault: preventDefaultSpy });
+
+    expect(mockSendTextMessageEventFunction).toHaveBeenCalledTimes(1);
+    expect(mockSendTextMessageEventFunction).toHaveBeenCalledWith(
+      mockuserRequestToAlexa,
+      undefined
+    );
+
+    mockSendTextMessageEventFunction.mockClear();
+  }
+});
+
 it("handles the user's form submission with request to Alexa and populates the state with the user request and Alexa's response", done => {
+  const mockAuthenticationInfo = { access_token: "mockAccessToken" };
+
   const alexaId = userIds.ALEXA;
   const alexa = users.get(alexaId);
   let expectedAlexaResponse = new Message({
@@ -122,10 +162,16 @@ it("handles the user's form submission with request to Alexa and populates the s
     senderName: alexa.name
   });
 
-  testOnUserRequestToAlexaSubmitHandling(expectedAlexaResponse, done);
+  testOnUserRequestToAlexaSubmitHandling(
+    mockAuthenticationInfo,
+    expectedAlexaResponse,
+    done
+  );
 });
 
 it("handles the case when AVS throws an error in response to a user request. We should populate the state with the user request and a canned response.", done => {
+  const mockAuthenticationInfo = { access_token: "mockAccessToken" };
+
   // mock the AVSGateway to throw an error.
   mockSendTextMessageEventFunction.mockImplementation(() =>
     Promise.reject(
@@ -141,7 +187,11 @@ it("handles the case when AVS throws an error in response to a user request. We 
     senderName: alexa.name
   });
 
-  testOnUserRequestToAlexaSubmitHandling(expectedAlexaResponse, done);
+  testOnUserRequestToAlexaSubmitHandling(
+    mockAuthenticationInfo,
+    expectedAlexaResponse,
+    done
+  );
 });
 
 it("handles gracefully when the input form is submitted with a null or empty request string", () => {
@@ -197,10 +247,13 @@ it("handles the user's input as they are typing their request (before submission
  * against.
  */
 const testOnUserRequestToAlexaSubmitHandling = (
+  mockAuthenticationInfo,
   expectedAlexaResponse,
   done
 ) => {
-  const chatWindow = mount(<ChatWindow />);
+  const chatWindow = mount(
+    <ChatWindow authenticationInfo={mockAuthenticationInfo} />
+  );
   const chatWindowInstance = chatWindow.instance();
   const originalState = JSON.parse(JSON.stringify(chatWindowInstance.state));
 
@@ -223,7 +276,8 @@ const testOnUserRequestToAlexaSubmitHandling = (
 
   expect(mockSendTextMessageEventFunction).toHaveBeenCalledTimes(1);
   expect(mockSendTextMessageEventFunction).toHaveBeenCalledWith(
-    mockuserRequestToAlexa
+    mockuserRequestToAlexa,
+    mockAuthenticationInfo.access_token
   );
 
   let expectedUserMessage = new Message({

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -7,7 +7,9 @@ exports[`renders correctly without crashing 1`] = `
   <Header
     updateAuthenticationInfo={[Function]}
   />
-  <Body />
+  <Body
+    authenticationInfo={Object {}}
+  />
   <Footer />
 </div>
 `;


### PR DESCRIPTION
Now that the access_token has been plumbed through the state, in this commit we start using it by passing the real access_token to AVSGateway. We have an end-end functioning silent Alexa with this commit.

Note that for now, we blindly pass the access_token regardless of whether or not it is valid and if it is even present. The assumption is that it is either

the 'App' component's responsibility to kick the user back to a login screen whenever the access_token is missing or expired.
OR
AVSGateway's responsibility to notify App to kick the user out whenever it receives a 403 from Alexa or notices a missing access_token.
Said logout mechanism will be implemented in a later commit.