### PR TITLE
Fix for https://github.com/s-maheshbabu/silent-alexa/issues/22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5407,10 +5407,11 @@
       }
     },
     "http-message-parser": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/http-message-parser/-/http-message-parser-0.0.22.tgz",
-      "integrity": "sha1-/xoNnaEDAF49NuZltfAwGjUX9Ko=",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/http-message-parser/-/http-message-parser-0.0.28.tgz",
+      "integrity": "sha512-Tjani/TWL2yKrvmufFC++nSiIZXNVIVnxjI+YxX577pEEADoEgkyfyH9SclDtsV0mK6hDbgklgpcqeTvPRtWcg==",
       "requires": {
+        "buffer": "4.9.1",
         "concat-stream": "1.6.0",
         "get-prop": "0.0.10",
         "minimist": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5148,11 +5148,6 @@
         "har-schema": "2.0.0"
       }
     },
-    "harmony-reflect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.0.tgz",
-      "integrity": "sha512-0kZ1XcoelFOLEjEtvWAZyq/1S55eDSieWEJwme311MNVNcRpvjlr2zA66kBV6WAB8C1XI1p1cXCnFPqd1BxlPg=="
-    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -5594,14 +5589,6 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "requires": {
         "postcss": "6.0.21"
-      }
-    },
-    "identity-obj-proxy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
-      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
-      "requires": {
-        "harmony-reflect": "1.6.0"
       }
     },
     "ieee754": {
@@ -7630,9 +7617,9 @@
       }
     },
     "npm": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-5.7.1.tgz",
-      "integrity": "sha512-r1grvv6mcEt+nlMzMWPc5n/z5q8NNuBWj0TGFp1PBSFCl6ubnAoUGBsucYsnZYT7MOJn0ha1ptEjmdBoAdJ+SA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-5.8.0.tgz",
+      "integrity": "sha512-DowXzQwtSWDtbAjuWecuEiismR0VdNEYaL3VxNTYTdW6AGkYxfGk9LUZ/rt6etEyiH4IEk95HkJeGfXE5Rz9xQ==",
       "requires": {
         "JSONStream": "1.3.2",
         "abbrev": "1.1.1",
@@ -7652,6 +7639,7 @@
         "config-chain": "1.1.11",
         "debuglog": "1.0.1",
         "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
         "dezalgo": "1.0.3",
         "editor": "1.0.0",
         "find-npm-prefix": "1.0.2",
@@ -7661,17 +7649,18 @@
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "has-unicode": "2.0.1",
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "iferr": "0.1.5",
         "imurmurhash": "0.1.4",
         "inflight": "1.0.6",
         "inherits": "2.0.3",
         "ini": "1.3.5",
-        "init-package-json": "1.10.1",
+        "init-package-json": "1.10.3",
         "is-cidr": "1.0.0",
+        "json-parse-better-errors": "1.0.1",
         "lazy-property": "1.0.0",
-        "libcipm": "1.3.3",
-        "libnpx": "9.7.1",
+        "libcipm": "1.6.0",
+        "libnpx": "10.0.1",
         "lockfile": "1.0.3",
         "lodash._baseindexof": "3.1.0",
         "lodash._baseuniq": "4.6.0",
@@ -7686,24 +7675,24 @@
         "lodash.without": "4.4.0",
         "lru-cache": "4.1.1",
         "meant": "1.0.1",
-        "mississippi": "2.0.0",
+        "mississippi": "3.0.0",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
         "nopt": "4.0.1",
         "normalize-package-data": "2.4.0",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.0.0",
+        "npm-lifecycle": "2.0.1",
         "npm-package-arg": "6.0.0",
         "npm-packlist": "1.1.10",
         "npm-profile": "3.0.1",
-        "npm-registry-client": "8.5.0",
+        "npm-registry-client": "8.5.1",
         "npm-user-validate": "1.0.0",
         "npmlog": "4.1.2",
         "once": "1.4.0",
         "opener": "1.4.3",
         "osenv": "0.1.5",
-        "pacote": "7.3.3",
+        "pacote": "7.6.1",
         "path-is-inside": "1.0.2",
         "promise-inflight": "1.0.1",
         "qrcode-terminal": "0.11.0",
@@ -7712,9 +7701,9 @@
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
         "read-installed": "4.0.3",
-        "read-package-json": "2.0.12",
+        "read-package-json": "2.0.13",
         "read-package-tree": "5.1.6",
-        "readable-stream": "2.3.4",
+        "readable-stream": "2.3.5",
         "readdir-scoped-modules": "1.0.2",
         "request": "2.83.0",
         "retry": "0.10.1",
@@ -7727,7 +7716,7 @@
         "sorted-union-stream": "2.1.3",
         "ssri": "5.2.4",
         "strip-ansi": "4.0.0",
-        "tar": "4.3.3",
+        "tar": "4.4.0",
         "text-table": "0.2.0",
         "uid-number": "0.0.6",
         "umask": "1.1.0",
@@ -7738,9 +7727,9 @@
         "validate-npm-package-license": "3.0.1",
         "validate-npm-package-name": "3.0.0",
         "which": "1.3.0",
-        "worker-farm": "1.5.2",
+        "worker-farm": "1.5.4",
         "wrappy": "1.0.2",
-        "write-file-atomic": "2.1.0"
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -7820,6 +7809,138 @@
             "y18n": "4.0.0"
           },
           "dependencies": {
+            "mississippi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "concat-stream": "1.6.1",
+                "duplexify": "3.5.4",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.2",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "2.0.1",
+                "pumpify": "1.4.0",
+                "stream-each": "1.2.2",
+                "through2": "2.0.3"
+              },
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.6.1",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5",
+                    "typedarray": "0.0.6"
+                  },
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "bundled": true
+                    }
+                  }
+                },
+                "duplexify": {
+                  "version": "3.5.4",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5",
+                    "stream-shift": "1.0.0"
+                  },
+                  "dependencies": {
+                    "stream-shift": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "end-of-stream": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.4.0"
+                  }
+                },
+                "flush-write-stream": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5"
+                  }
+                },
+                "from2": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5"
+                  }
+                },
+                "parallel-transform": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "cyclist": "0.2.2",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5"
+                  },
+                  "dependencies": {
+                    "cyclist": {
+                      "version": "0.2.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "pump": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
+                  }
+                },
+                "pumpify": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "duplexify": "3.5.4",
+                    "inherits": "2.0.3",
+                    "pump": "2.0.1"
+                  }
+                },
+                "stream-each": {
+                  "version": "1.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "stream-shift": "1.0.0"
+                  },
+                  "dependencies": {
+                    "stream-shift": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "2.3.5",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "xtend": {
+                      "version": "4.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
             "y18n": {
               "version": "4.0.0",
               "bundled": true
@@ -7970,6 +8091,10 @@
           "version": "5.0.0",
           "bundled": true
         },
+        "detect-newline": {
+          "version": "2.1.0",
+          "bundled": true
+        },
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
@@ -8008,7 +8133,7 @@
             "graceful-fs": "4.1.11",
             "iferr": "0.1.5",
             "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           }
         },
         "gentle-fs": {
@@ -8083,7 +8208,7 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.5.0",
+          "version": "2.6.0",
           "bundled": true
         },
         "iferr": {
@@ -8111,29 +8236,19 @@
           "bundled": true
         },
         "init-package-json": {
-          "version": "1.10.1",
+          "version": "1.10.3",
           "bundled": true,
           "requires": {
             "glob": "7.1.2",
-            "npm-package-arg": "5.1.2",
+            "npm-package-arg": "6.0.0",
             "promzard": "0.3.0",
             "read": "1.0.7",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.13",
             "semver": "5.5.0",
             "validate-npm-package-license": "3.0.1",
             "validate-npm-package-name": "3.0.0"
           },
           "dependencies": {
-            "npm-package-arg": {
-              "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.5",
-                "semver": "5.5.0",
-                "validate-npm-package-name": "3.0.0"
-              }
-            },
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
@@ -8156,12 +8271,16 @@
             }
           }
         },
+        "json-parse-better-errors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
         "lazy-property": {
           "version": "1.0.0",
           "bundled": true
         },
         "libcipm": {
-          "version": "1.3.3",
+          "version": "1.6.0",
           "bundled": true,
           "requires": {
             "bin-links": "1.1.0",
@@ -8169,20 +8288,16 @@
             "find-npm-prefix": "1.0.2",
             "graceful-fs": "4.1.11",
             "lock-verify": "2.0.0",
-            "npm-lifecycle": "2.0.0",
+            "npm-lifecycle": "2.0.1",
             "npm-logical-tree": "1.2.1",
             "npm-package-arg": "6.0.0",
-            "pacote": "7.3.3",
+            "pacote": "7.6.1",
             "protoduck": "5.0.0",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.13",
             "rimraf": "2.6.2",
-            "worker-farm": "1.5.2"
+            "worker-farm": "1.5.4"
           },
           "dependencies": {
-            "find-npm-prefix": {
-              "version": "1.0.2",
-              "bundled": true
-            },
             "lock-verify": {
               "version": "2.0.0",
               "bundled": true,
@@ -8195,7 +8310,7 @@
                   "version": "5.1.2",
                   "bundled": true,
                   "requires": {
-                    "hosted-git-info": "2.5.0",
+                    "hosted-git-info": "2.6.0",
                     "osenv": "0.1.5",
                     "semver": "5.5.0",
                     "validate-npm-package-name": "3.0.0"
@@ -8221,7 +8336,7 @@
               }
             },
             "worker-farm": {
-              "version": "1.5.2",
+              "version": "1.5.4",
               "bundled": true,
               "requires": {
                 "errno": "0.1.7",
@@ -8250,116 +8365,103 @@
           }
         },
         "libnpx": {
-          "version": "9.7.1",
+          "version": "10.0.1",
           "bundled": true,
           "requires": {
-            "dotenv": "4.0.0",
-            "npm-package-arg": "5.1.2",
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.0.0",
             "rimraf": "2.6.2",
             "safe-buffer": "5.1.1",
             "update-notifier": "2.3.0",
             "which": "1.3.0",
-            "y18n": "3.2.1",
-            "yargs": "8.0.2"
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
           },
           "dependencies": {
             "dotenv": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "y18n": {
               "version": "4.0.0",
               "bundled": true
             },
-            "npm-package-arg": {
-              "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.5",
-                "semver": "5.5.0",
-                "validate-npm-package-name": "3.0.0"
-              }
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true
-            },
             "yargs": {
-              "version": "8.0.2",
+              "version": "11.0.0",
               "bundled": true,
               "requires": {
-                "camelcase": "4.1.0",
-                "cliui": "3.2.0",
+                "cliui": "4.0.0",
                 "decamelize": "1.2.0",
+                "find-up": "2.1.0",
                 "get-caller-file": "1.0.2",
                 "os-locale": "2.1.0",
-                "read-pkg-up": "2.0.0",
                 "require-directory": "2.1.1",
                 "require-main-filename": "1.0.1",
                 "set-blocking": "2.0.0",
                 "string-width": "2.1.1",
                 "which-module": "2.0.0",
                 "y18n": "3.2.1",
-                "yargs-parser": "7.0.0"
+                "yargs-parser": "9.0.2"
               },
               "dependencies": {
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                },
                 "cliui": {
-                  "version": "3.2.0",
+                  "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
+                    "string-width": "2.1.1",
+                    "strip-ansi": "4.0.0",
                     "wrap-ansi": "2.1.0"
                   },
                   "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    },
                     "wrap-ansi": {
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
                         "string-width": "1.0.2",
                         "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "number-is-nan": "1.0.1"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -8367,6 +8469,51 @@
                 "decamelize": {
                   "version": "1.2.0",
                   "bundled": true
+                },
+                "find-up": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "2.0.0"
+                  },
+                  "dependencies": {
+                    "locate-path": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                      },
+                      "dependencies": {
+                        "p-locate": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "p-limit": "1.2.0"
+                          },
+                          "dependencies": {
+                            "p-limit": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "p-try": "1.0.0"
+                              },
+                              "dependencies": {
+                                "p-try": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-exists": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
                 },
                 "get-caller-file": {
                   "version": "1.0.2",
@@ -8470,124 +8617,12 @@
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "mimic-fn": "1.1.0"
+                        "mimic-fn": "1.2.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
-                          "version": "1.1.0",
+                          "version": "1.2.0",
                           "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "find-up": "2.1.0",
-                    "read-pkg": "2.0.0"
-                  },
-                  "dependencies": {
-                    "find-up": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "locate-path": "2.0.0"
-                      },
-                      "dependencies": {
-                        "locate-path": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "p-locate": "2.0.0",
-                            "path-exists": "3.0.0"
-                          },
-                          "dependencies": {
-                            "p-locate": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "p-limit": "1.1.0"
-                              },
-                              "dependencies": {
-                                "p-limit": {
-                                  "version": "1.1.0",
-                                  "bundled": true
-                                }
-                              }
-                            },
-                            "path-exists": {
-                              "version": "3.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "load-json-file": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "2.0.0"
-                      },
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "graceful-fs": "4.1.11",
-                            "parse-json": "2.2.0",
-                            "pify": "2.3.0",
-                            "strip-bom": "3.0.0"
-                          },
-                          "dependencies": {
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "error-ex": "1.3.1"
-                              },
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.1",
-                                  "bundled": true,
-                                  "requires": {
-                                    "is-arrayish": "0.2.1"
-                                  },
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "bundled": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "bundled": true
-                            },
-                            "strip-bom": {
-                              "version": "3.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "pify": "2.3.0"
-                          },
-                          "dependencies": {
-                            "pify": {
-                              "version": "2.3.0",
-                              "bundled": true
-                            }
-                          }
                         }
                       }
                     }
@@ -8623,11 +8658,21 @@
                   "version": "2.0.0",
                   "bundled": true
                 },
+                "y18n": {
+                  "version": "3.2.1",
+                  "bundled": true
+                },
                 "yargs-parser": {
-                  "version": "7.0.0",
+                  "version": "9.0.2",
                   "bundled": true,
                   "requires": {
                     "camelcase": "4.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    }
                   }
                 }
               }
@@ -8722,27 +8767,27 @@
           "bundled": true
         },
         "mississippi": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.0",
-            "duplexify": "3.5.3",
+            "concat-stream": "1.6.1",
+            "duplexify": "3.5.4",
             "end-of-stream": "1.4.1",
             "flush-write-stream": "1.0.2",
             "from2": "2.3.0",
             "parallel-transform": "1.1.0",
-            "pump": "2.0.1",
+            "pump": "3.0.0",
             "pumpify": "1.4.0",
             "stream-each": "1.2.2",
             "through2": "2.0.3"
           },
           "dependencies": {
             "concat-stream": {
-              "version": "1.6.0",
+              "version": "1.6.1",
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.4",
+                "readable-stream": "2.3.5",
                 "typedarray": "0.0.6"
               },
               "dependencies": {
@@ -8753,12 +8798,12 @@
               }
             },
             "duplexify": {
-              "version": "3.5.3",
+              "version": "3.5.4",
               "bundled": true,
               "requires": {
                 "end-of-stream": "1.4.1",
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.4",
+                "readable-stream": "2.3.5",
                 "stream-shift": "1.0.0"
               },
               "dependencies": {
@@ -8780,7 +8825,7 @@
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.4"
+                "readable-stream": "2.3.5"
               }
             },
             "from2": {
@@ -8788,7 +8833,7 @@
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.4"
+                "readable-stream": "2.3.5"
               }
             },
             "parallel-transform": {
@@ -8797,7 +8842,7 @@
               "requires": {
                 "cyclist": "0.2.2",
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.4"
+                "readable-stream": "2.3.5"
               },
               "dependencies": {
                 "cyclist": {
@@ -8807,7 +8852,7 @@
               }
             },
             "pump": {
-              "version": "2.0.1",
+              "version": "3.0.0",
               "bundled": true,
               "requires": {
                 "end-of-stream": "1.4.1",
@@ -8818,9 +8863,19 @@
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "duplexify": "3.5.3",
+                "duplexify": "3.5.4",
                 "inherits": "2.0.3",
                 "pump": "2.0.1"
+              },
+              "dependencies": {
+                "pump": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
+                  }
+                }
               }
             },
             "stream-each": {
@@ -8841,7 +8896,7 @@
               "version": "2.0.3",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.4",
+                "readable-stream": "2.3.5",
                 "xtend": "4.0.1"
               },
               "dependencies": {
@@ -8899,93 +8954,6 @@
             }
           }
         },
-        "node-gyp": {
-          "version": "3.6.2",
-          "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.5",
-            "request": "2.83.0",
-            "rimraf": "2.6.2",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.3.0"
-          },
-          "dependencies": {
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1.1.1"
-              }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3"
-                  }
-                }
-              }
-            }
-          }
-        },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
@@ -8998,7 +8966,7 @@
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
+            "hosted-git-info": "2.6.0",
             "is-builtin-module": "1.0.0",
             "semver": "5.5.0",
             "validate-npm-package-license": "3.0.1"
@@ -9031,7 +8999,7 @@
           }
         },
         "npm-lifecycle": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "requires": {
             "byline": "5.0.0",
@@ -9048,6 +9016,93 @@
               "version": "5.0.0",
               "bundled": true
             },
+            "node-gyp": {
+              "version": "3.6.2",
+              "bundled": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "npmlog": "4.1.2",
+                "osenv": "0.1.5",
+                "request": "2.83.0",
+                "rimraf": "2.6.2",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "which": "1.3.0"
+              },
+              "dependencies": {
+                "fstream": {
+                  "version": "1.0.11",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.2"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.11"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.11",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "abbrev": "1.1.1"
+                  }
+                },
+                "semver": {
+                  "version": "5.3.0",
+                  "bundled": true
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "block-stream": "0.0.9",
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3"
+                  },
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.9",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3"
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "resolve-from": {
               "version": "4.0.0",
               "bundled": true
@@ -9058,7 +9113,7 @@
           "version": "6.0.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
+            "hosted-git-info": "2.6.0",
             "osenv": "0.1.5",
             "semver": "5.5.0",
             "validate-npm-package-name": "3.0.0"
@@ -9276,7 +9331,7 @@
                       "bundled": true,
                       "requires": {
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4",
+                        "readable-stream": "2.3.5",
                         "typedarray": "0.0.6"
                       },
                       "dependencies": {
@@ -9292,7 +9347,7 @@
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4",
+                        "readable-stream": "2.3.5",
                         "stream-shift": "1.0.0"
                       },
                       "dependencies": {
@@ -9314,7 +9369,7 @@
                       "bundled": true,
                       "requires": {
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "from2": {
@@ -9322,7 +9377,7 @@
                       "bundled": true,
                       "requires": {
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "parallel-transform": {
@@ -9331,7 +9386,7 @@
                       "requires": {
                         "cyclist": "0.2.2",
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
+                        "readable-stream": "2.3.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -9385,7 +9440,7 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "2.3.4",
+                        "readable-stream": "2.3.5",
                         "xtend": "4.0.1"
                       },
                       "dependencies": {
@@ -9494,28 +9549,29 @@
           }
         },
         "npm-registry-client": {
-          "version": "8.5.0",
+          "version": "8.5.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.0",
+            "concat-stream": "1.6.1",
             "graceful-fs": "4.1.11",
             "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
+            "npm-package-arg": "6.0.0",
             "npmlog": "4.1.2",
             "once": "1.4.0",
             "request": "2.83.0",
             "retry": "0.10.1",
+            "safe-buffer": "5.1.1",
             "semver": "5.5.0",
             "slide": "1.1.6",
-            "ssri": "4.1.6"
+            "ssri": "5.2.4"
           },
           "dependencies": {
             "concat-stream": {
-              "version": "1.6.0",
+              "version": "1.6.1",
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.4",
+                "readable-stream": "2.3.5",
                 "typedarray": "0.0.6"
               },
               "dependencies": {
@@ -9523,23 +9579,6 @@
                   "version": "0.0.6",
                   "bundled": true
                 }
-              }
-            },
-            "npm-package-arg": {
-              "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.5",
-                "semver": "5.5.0",
-                "validate-npm-package-name": "3.0.0"
-              }
-            },
-            "ssri": {
-              "version": "4.1.6",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -9563,7 +9602,7 @@
               "bundled": true,
               "requires": {
                 "delegates": "1.0.0",
-                "readable-stream": "2.3.4"
+                "readable-stream": "2.3.5"
               },
               "dependencies": {
                 "delegates": {
@@ -9684,7 +9723,7 @@
           }
         },
         "pacote": {
-          "version": "7.3.3",
+          "version": "7.6.1",
           "bundled": true,
           "requires": {
             "bluebird": "3.5.1",
@@ -9694,7 +9733,8 @@
             "lru-cache": "4.1.1",
             "make-fetch-happen": "2.6.0",
             "minimatch": "3.0.4",
-            "mississippi": "2.0.0",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
             "normalize-package-data": "2.4.0",
             "npm-package-arg": "6.0.0",
             "npm-packlist": "1.1.10",
@@ -9703,10 +9743,11 @@
             "promise-inflight": "1.0.1",
             "promise-retry": "1.1.1",
             "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
             "safe-buffer": "5.1.1",
             "semver": "5.5.0",
             "ssri": "5.2.4",
-            "tar": "4.3.3",
+            "tar": "4.4.0",
             "unique-filename": "1.1.0",
             "which": "1.3.0"
           },
@@ -9719,11 +9760,11 @@
               "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.3.0",
+                "agentkeepalive": "3.4.0",
                 "cacache": "10.0.4",
                 "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.0",
                 "lru-cache": "4.1.1",
                 "mississippi": "1.3.1",
                 "node-fetch-npm": "2.0.2",
@@ -9733,7 +9774,7 @@
               },
               "dependencies": {
                 "agentkeepalive": {
-                  "version": "3.3.0",
+                  "version": "3.4.0",
                   "bundled": true,
                   "requires": {
                     "humanize-ms": "1.2.1"
@@ -9759,11 +9800,11 @@
                   "bundled": true
                 },
                 "http-proxy-agent": {
-                  "version": "2.0.0",
+                  "version": "2.1.0",
                   "bundled": true,
                   "requires": {
                     "agent-base": "4.2.0",
-                    "debug": "2.6.9"
+                    "debug": "3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -9789,7 +9830,7 @@
                       }
                     },
                     "debug": {
-                      "version": "2.6.9",
+                      "version": "3.1.0",
                       "bundled": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -9804,7 +9845,7 @@
                   }
                 },
                 "https-proxy-agent": {
-                  "version": "2.1.1",
+                  "version": "2.2.0",
                   "bundled": true,
                   "requires": {
                     "agent-base": "4.2.0",
@@ -9852,8 +9893,8 @@
                   "version": "1.3.1",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "1.6.0",
-                    "duplexify": "3.5.3",
+                    "concat-stream": "1.6.1",
+                    "duplexify": "3.5.4",
                     "end-of-stream": "1.4.1",
                     "flush-write-stream": "1.0.2",
                     "from2": "2.3.0",
@@ -9865,11 +9906,11 @@
                   },
                   "dependencies": {
                     "concat-stream": {
-                      "version": "1.6.0",
+                      "version": "1.6.1",
                       "bundled": true,
                       "requires": {
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4",
+                        "readable-stream": "2.3.5",
                         "typedarray": "0.0.6"
                       },
                       "dependencies": {
@@ -9880,12 +9921,12 @@
                       }
                     },
                     "duplexify": {
-                      "version": "3.5.3",
+                      "version": "3.5.4",
                       "bundled": true,
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4",
+                        "readable-stream": "2.3.5",
                         "stream-shift": "1.0.0"
                       },
                       "dependencies": {
@@ -9907,7 +9948,7 @@
                       "bundled": true,
                       "requires": {
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "from2": {
@@ -9915,7 +9956,7 @@
                       "bundled": true,
                       "requires": {
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "parallel-transform": {
@@ -9924,7 +9965,7 @@
                       "requires": {
                         "cyclist": "0.2.2",
                         "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
+                        "readable-stream": "2.3.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -9945,7 +9986,7 @@
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "3.5.3",
+                        "duplexify": "3.5.4",
                         "inherits": "2.0.3",
                         "pump": "2.0.1"
                       },
@@ -9978,7 +10019,7 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "2.3.4",
+                        "readable-stream": "2.3.5",
                         "xtend": "4.0.1"
                       },
                       "dependencies": {
@@ -10097,138 +10138,6 @@
                 }
               }
             },
-            "mississippi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "concat-stream": "1.6.0",
-                "duplexify": "3.5.3",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.2",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.4.0",
-                "stream-each": "1.2.2",
-                "through2": "2.0.3"
-              },
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4",
-                    "typedarray": "0.0.6"
-                  },
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "bundled": true
-                    }
-                  }
-                },
-                "duplexify": {
-                  "version": "3.5.3",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "1.4.1",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4",
-                    "stream-shift": "1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "end-of-stream": {
-                  "version": "1.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "once": "1.4.0"
-                  }
-                },
-                "flush-write-stream": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4"
-                  }
-                },
-                "from2": {
-                  "version": "2.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4"
-                  }
-                },
-                "parallel-transform": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "cyclist": "0.2.2",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4"
-                  },
-                  "dependencies": {
-                    "cyclist": {
-                      "version": "0.2.2",
-                      "bundled": true
-                    }
-                  }
-                },
-                "pump": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
-                  }
-                },
-                "pumpify": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "duplexify": "3.5.3",
-                    "inherits": "2.0.3",
-                    "pump": "2.0.1"
-                  }
-                },
-                "stream-each": {
-                  "version": "1.2.2",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "1.4.1",
-                    "stream-shift": "1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "through2": {
-                  "version": "2.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "readable-stream": "2.3.4",
-                    "xtend": "4.0.1"
-                  },
-                  "dependencies": {
-                    "xtend": {
-                      "version": "4.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
             "npm-pick-manifest": {
               "version": "2.1.0",
               "bundled": true,
@@ -10263,10 +10172,6 @@
                   "bundled": true
                 }
               }
-            },
-            "semver": {
-              "version": "5.5.0",
-              "bundled": true
             }
           }
         },
@@ -10335,7 +10240,7 @@
           "requires": {
             "debuglog": "1.0.1",
             "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.13",
             "readdir-scoped-modules": "1.0.2",
             "semver": "5.5.0",
             "slide": "1.1.6",
@@ -10349,7 +10254,7 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.12",
+          "version": "2.0.13",
           "bundled": true,
           "requires": {
             "glob": "7.1.2",
@@ -10376,12 +10281,12 @@
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
             "once": "1.4.0",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.13",
             "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
-          "version": "2.3.4",
+          "version": "2.3.5",
           "bundled": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -10798,7 +10703,7 @@
           "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           }
         },
         "slide": {
@@ -10855,7 +10760,7 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.4",
+                "readable-stream": "2.3.5",
                 "stream-shift": "1.0.0"
               },
               "dependencies": {
@@ -10888,7 +10793,7 @@
           }
         },
         "tar": {
-          "version": "4.3.3",
+          "version": "4.4.0",
           "bundled": true,
           "requires": {
             "chownr": "1.0.1",
@@ -11206,7 +11111,7 @@
                 "graceful-fs": "4.1.11",
                 "make-dir": "1.0.0",
                 "unique-string": "1.0.0",
-                "write-file-atomic": "2.1.0",
+                "write-file-atomic": "2.3.0",
                 "xdg-basedir": "3.0.0"
               },
               "dependencies": {
@@ -11519,7 +11424,7 @@
           }
         },
         "worker-farm": {
-          "version": "1.5.2",
+          "version": "1.5.4",
           "bundled": true,
           "requires": {
             "errno": "0.1.7",
@@ -11550,12 +11455,18 @@
           "bundled": true
         },
         "write-file-atomic": {
-          "version": "2.1.0",
+          "version": "2.3.0",
           "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "signal-exit": "3.0.2"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            }
           }
         }
       }
@@ -13649,852 +13560,6 @@
         "whatwg-fetch": "2.0.3"
       },
       "dependencies": {
-        "promise": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
-          "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
-          "requires": {
-            "asap": "2.0.6"
-          }
-        }
-      }
-    },
-    "react-scripts-cssmodules": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/react-scripts-cssmodules/-/react-scripts-cssmodules-1.1.10.tgz",
-      "integrity": "sha512-X0iiFvv0+hlKEojwI2kh+ctVvPf+hn0tzSrYpCpn685aSl6af5r/3xHyjzG7YdPH1OMlxPrDW5PdxKveVsLHjw==",
-      "requires": {
-        "autoprefixer": "7.1.6",
-        "babel-core": "6.26.0",
-        "babel-eslint": "7.2.3",
-        "babel-jest": "20.0.3",
-        "babel-loader": "7.1.2",
-        "babel-preset-react-app": "3.1.1",
-        "babel-runtime": "6.26.0",
-        "case-sensitive-paths-webpack-plugin": "2.1.1",
-        "chalk": "1.1.3",
-        "css-loader": "0.28.7",
-        "dotenv": "4.0.0",
-        "dotenv-expand": "4.0.1",
-        "eslint": "4.10.0",
-        "eslint-config-react-app": "2.1.0",
-        "eslint-loader": "1.9.0",
-        "eslint-plugin-flowtype": "2.39.1",
-        "eslint-plugin-import": "2.8.0",
-        "eslint-plugin-jsx-a11y": "5.1.1",
-        "eslint-plugin-react": "7.4.0",
-        "extract-text-webpack-plugin": "3.0.2",
-        "file-loader": "1.1.5",
-        "fs-extra": "3.0.1",
-        "fsevents": "1.1.2",
-        "html-webpack-plugin": "2.29.0",
-        "identity-obj-proxy": "3.0.0",
-        "jest": "20.0.4",
-        "object-assign": "4.1.1",
-        "postcss-flexbugs-fixes": "3.2.0",
-        "postcss-loader": "2.0.8",
-        "promise": "8.0.1",
-        "raf": "3.4.0",
-        "react-dev-utils": "5.0.1",
-        "style-loader": "0.19.0",
-        "sw-precache-webpack-plugin": "0.11.4",
-        "url-loader": "0.6.2",
-        "webpack": "3.8.1",
-        "webpack-dev-server": "2.9.4",
-        "webpack-manifest-plugin": "1.3.2",
-        "whatwg-fetch": "2.0.3"
-      },
-      "dependencies": {
-        "dotenv-expand": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.0.1.tgz",
-          "integrity": "sha1-aP3cFWGBTgoQlkERBX/xOM7X16g="
-        },
-        "fsevents": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-          "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-          "optional": true,
-          "requires": {
-            "nan": "2.10.0",
-            "node-pre-gyp": "0.6.36"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "aproba": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.2.9"
-              }
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            },
-            "boom": {
-              "version": "2.10.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.7",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "0.4.2",
-                "concat-map": "0.0.1"
-              }
-            },
-            "buffer-shims": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true,
-              "optional": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "boom": "2.10.1"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true,
-              "optional": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "extsprintf": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true,
-              "optional": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              }
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aproba": "1.1.1",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "bundled": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.0"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "jodid25519": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "jsprim": {
-              "version": "1.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.0.2",
-                "json-schema": "0.2.3",
-                "verror": "1.3.6"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.27.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.27.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "node-pre-gyp": {
-              "version": "0.6.36",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.0",
-                "rc": "1.2.1",
-                "request": "2.81.0",
-                "rimraf": "2.6.1",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.0"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1.1.0",
-                "osenv": "0.1.4"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true,
-              "optional": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.2.9",
-              "bundled": true,
-              "requires": {
-                "buffer-shims": "1.0.0",
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "1.0.1",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.15",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.0.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.0.1"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true,
-              "requires": {
-                "glob": "7.1.2"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "sshpk": {
-              "version": "1.13.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jodid25519": "1.0.2",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
-              }
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "debug": "2.6.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.2.9",
-                "rimraf": "2.6.1",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true,
-              "optional": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "verror": {
-              "version": "1.3.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "extsprintf": "1.0.2"
-              }
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "string-width": "1.0.2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
         "promise": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "http-message-parser": "0.0.22",
     "immutable": "^4.0.0-rc.9",
     "material-ui": "^0.20.0",
-    "npm": "^5.7.1",
+    "npm": "^5.8.0",
     "react": "^16.2.0",
     "react-chat-ui": "^0.3.0",
     "react-container-dimensions": "^1.3.3",
@@ -33,6 +33,8 @@
     "sprintf-js": "^1.1.1"
   },
   "jest": {
-    "snapshotSerializers": ["enzyme-to-json/serializer"]
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://s-maheshbabu.github.io/silent-alexa",
   "dependencies": {
     "gh-pages": "^1.1.0",
-    "http-message-parser": "0.0.22",
+    "http-message-parser": "0.0.28",
     "immutable": "^4.0.0-rc.9",
     "material-ui": "^0.20.0",
     "npm": "^5.8.0",

--- a/src/AVSGateway.js
+++ b/src/AVSGateway.js
@@ -3,13 +3,13 @@ import { cannedErrorResponses, customErrorCodes } from "./CannedErrorResponses";
 import { cannedResponses } from "./CannedResponses";
 
 import IllegalArgumentError from "./errors/IllegalArgumentError";
+import { extractAlexaTextResponse as parser } from "./SpeakDirectiveParser";
 
-const uuid = require("uuid/v4");
-const util = require("util");
-const { hasIn, List } = require("immutable");
+import { hasIn, List } from "immutable";
+import uuid from "uuid/v4";
+import util from "util";
+
 const sprintf = require("sprintf-js").sprintf;
-
-const parser = require("./SpeakDirectiveParser");
 
 const AVS_REQUEST_BODY = `--silent-alexa-http-boundary
 Content-Disposition: form-data; name="metadata"
@@ -77,7 +77,7 @@ export default class AVSGateway {
 
     if (isOk) {
       try {
-        let textResponsesFromAlexa = parser.extractAlexaTextResponse(payload);
+        let textResponsesFromAlexa = parser(payload);
         if (!textResponsesFromAlexa || !textResponsesFromAlexa.get(0))
           textResponsesFromAlexa = List.of(
             cannedResponses.EMPTY_RESPONSE_FROM_ALEXA

--- a/src/AVSGateway.js
+++ b/src/AVSGateway.js
@@ -78,7 +78,13 @@ export default class AVSGateway {
     if (isOk) {
       try {
         let textResponsesFromAlexa = parser(payload);
-        if (!textResponsesFromAlexa || !textResponsesFromAlexa.get(0))
+        if (
+          !textResponsesFromAlexa ||
+          // We don't anticipate Alexa to return a response in multiple parts where the first part is empty
+          // but the other parts aren't. So, the moment we see that the first part is empty, it is safe to
+          // ignore all other parts (which probably don't exist).
+          !textResponsesFromAlexa.get(0)
+        )
           textResponsesFromAlexa = List.of(
             cannedResponses.EMPTY_RESPONSE_FROM_ALEXA
           );

--- a/src/AVSGateway.test.js
+++ b/src/AVSGateway.test.js
@@ -13,8 +13,8 @@ import testData from "./test-data/multipart-response-test-data";
 // A mock parser that uses the real implementation by default.
 jest.mock("./SpeakDirectiveParser", () => {
   return {
-    extractAlexaTextResponse: jest.fn(
-      require.requireActual("./SpeakDirectiveParser").extractAlexaTextResponse
+    extractAlexaTextResponses: jest.fn(
+      require.requireActual("./SpeakDirectiveParser").extractAlexaTextResponses
     )
   };
 });
@@ -148,7 +148,7 @@ it("handles gracefully when the speak directive parser throws an error", async (
   const access_token = "a mock access_token";
 
   // Mock the parser to throw an illegal argument error
-  parser.extractAlexaTextResponse.mockImplementationOnce(() => {
+  parser.extractAlexaTextResponses.mockImplementationOnce(() => {
     throw new IllegalArgumentError("simulating an illegal argument error");
   });
 
@@ -193,7 +193,7 @@ it("calls fetch with the right options when trying to send a happy case TextMess
   await unitUnderTest
     .sendTextMessageEvent(userRequestToAlexa, access_token)
     .then(alexaResponse => {
-      expect(alexaResponse).toEqual(testData.happy_case.alexaResponse);
+      expect(alexaResponse).toEqual(testData.happy_case.alexaResponses);
     });
 
   const requestOptionsUsed = fetchMock.lastOptions();

--- a/src/AVSGateway.test.js
+++ b/src/AVSGateway.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-const { List } = require("immutable");
+import { List } from "immutable";
 
 import AVSGateway from "./AVSGateway";
 import { EVENTS_URL } from "./AVSGateway";

--- a/src/AVSGateway.test.js
+++ b/src/AVSGateway.test.js
@@ -1,4 +1,5 @@
 import React from "react";
+const { List } = require("immutable");
 
 import AVSGateway from "./AVSGateway";
 import { EVENTS_URL } from "./AVSGateway";
@@ -119,7 +120,7 @@ it("handles gracefully if AVS returns an unexpected error code", async () => {
     .sendTextMessageEvent(userRequestToAlexa, access_token)
     .then(alexaResponse => {
       expect(alexaResponse).toEqual(
-        cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR)
+        List.of(cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR))
       );
     });
 });
@@ -137,7 +138,7 @@ it("handles gracefully when the http response is 'ok' and then we fail to parse 
     .sendTextMessageEvent(userRequestToAlexa, access_token)
     .then(alexaResponse => {
       expect(alexaResponse).toEqual(
-        cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR)
+        List.of(cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR))
       );
     });
 });
@@ -160,7 +161,7 @@ it("handles gracefully when the speak directive parser throws an error", async (
     .sendTextMessageEvent(userRequestToAlexa, access_token)
     .then(alexaResponse => {
       expect(alexaResponse).toEqual(
-        cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR)
+        List.of(cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR))
       );
     });
 });
@@ -178,7 +179,7 @@ it("handles gracefully when the http response is not 'ok' and then we fail to pa
     .sendTextMessageEvent(userRequestToAlexa, access_token)
     .then(alexaResponse => {
       expect(alexaResponse).toEqual(
-        cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR)
+        List.of(cannedErrorResponses.get(customErrorCodes.UNKNOWN_ERROR))
       );
     });
 });
@@ -211,7 +212,9 @@ it("handles the happy case where Alexa returns an empty response. This can happe
   await unitUnderTest
     .sendTextMessageEvent(userRequestToAlexa, access_token)
     .then(alexaResponse => {
-      expect(alexaResponse).toEqual(cannedResponses.EMPTY_RESPONSE_FROM_ALEXA);
+      expect(alexaResponse).toEqual(
+        List.of(cannedResponses.EMPTY_RESPONSE_FROM_ALEXA)
+      );
     });
 
   const requestOptionsUsed = fetchMock.lastOptions();
@@ -248,6 +251,8 @@ const testErrorResponseFromAVSHandling = async (
   await unitUnderTest
     .sendTextMessageEvent(userRequestToAlexa, access_token)
     .then(alexaResponse => {
-      expect(alexaResponse).toEqual(cannedErrorResponses.get(avsErrorCode));
+      expect(alexaResponse).toEqual(
+        List.of(cannedErrorResponses.get(avsErrorCode))
+      );
     });
 };

--- a/src/ChatWindow.js
+++ b/src/ChatWindow.js
@@ -172,10 +172,11 @@ class ChatWindow extends Component {
     // TODO: Do not make a call to avs if access_token is undefined. Redirect the user to login screen.
     avs
       .sendTextMessageEvent(userRequestToAlexa, access_token)
-      .then(alexaResponses => {
-        for (let alexaResponse of alexaResponses)
-          this.pushMessage(chatterIds.ALEXA, alexaResponse);
-      })
+      .then(alexaResponses =>
+        alexaResponses.map(alexaResponse =>
+          this.pushMessage(chatterIds.ALEXA, alexaResponse)
+        )
+      )
       .catch(error => {
         // TODO: Don't show this as an Alexa bubble. It also doesn't make sense to show it as a user bubble.
         // Need to find a way to represent this error on the UI.

--- a/src/ChatWindow.js
+++ b/src/ChatWindow.js
@@ -172,11 +172,12 @@ class ChatWindow extends Component {
     // TODO: Do not make a call to avs if access_token is undefined. Redirect the user to login screen.
     avs
       .sendTextMessageEvent(userRequestToAlexa, access_token)
-      .then(response => {
-        this.pushMessage(chatterIds.ALEXA, response);
+      .then(alexaResponses => {
+        for (let alexaResponse of alexaResponses)
+          this.pushMessage(chatterIds.ALEXA, alexaResponse);
       })
       .catch(error => {
-        // TODO: Don't show this as an Alexa bubble. It also doesn't make to show it as a user bubble.
+        // TODO: Don't show this as an Alexa bubble. It also doesn't make sense to show it as a user bubble.
         // Need to find a way to represent this error on the UI.
         this.pushMessage(
           chatterIds.ALEXA,

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -302,8 +302,8 @@ const testOnUserRequestToAlexaSubmitHandling = (
     const finalMessages = finalState.messages;
 
     // We should have added userMessage and all of Alexa's responses.
-    const numberOfAlexaResponses = expectedAlexaResponses.size;
-    const numberOfNewMessagesToGoIntoState = 1 + numberOfAlexaResponses;
+    const numberOfExpectedAlexaResponses = expectedAlexaResponses.size;
+    const numberOfNewMessagesToGoIntoState = 1 + numberOfExpectedAlexaResponses;
 
     expect(finalMessages.length).toBe(
       numberOfMessagesAlreadyInState + numberOfNewMessagesToGoIntoState
@@ -311,9 +311,9 @@ const testOnUserRequestToAlexaSubmitHandling = (
     expect(
       finalMessages[finalMessages.length - numberOfNewMessagesToGoIntoState]
     ).toEqual(expectedUserMessage);
-    for (let i = numberOfAlexaResponses; i > 0; i--) {
+    for (let i = numberOfExpectedAlexaResponses; i > 0; i--) {
       expect(finalMessages[finalMessages.length - i]).toEqual(
-        expectedAlexaResponses.get(numberOfAlexaResponses - i)
+        expectedAlexaResponses.get(numberOfExpectedAlexaResponses - i)
       );
     }
 

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -253,7 +253,7 @@ it("handles the user's input as they are typing their request (before submission
 /**
  * Helper method to test the interaction with Alexa. Will simulate a user request and
  * verify that the expected messages are populated into the state.
- * @param {Message} expectedAlexaResponses The expected response from Alexa to be verified
+ * @param {Message} expectedAlexaResponses The expected responses from Alexa to be verified
  * against.
  */
 const testOnUserRequestToAlexaSubmitHandling = (
@@ -303,13 +303,13 @@ const testOnUserRequestToAlexaSubmitHandling = (
 
     // We should have added userMessage and all of Alexa's responses.
     const numberOfAlexaResponses = expectedAlexaResponses.size;
-    const numberOfNewMessagesInState = 1 + numberOfAlexaResponses;
+    const numberOfNewMessagesToGoIntoState = 1 + numberOfAlexaResponses;
 
     expect(finalMessages.length).toBe(
-      numberOfMessagesAlreadyInState + numberOfNewMessagesInState
+      numberOfMessagesAlreadyInState + numberOfNewMessagesToGoIntoState
     );
     expect(
-      finalMessages[finalMessages.length - numberOfNewMessagesInState]
+      finalMessages[finalMessages.length - numberOfNewMessagesToGoIntoState]
     ).toEqual(expectedUserMessage);
     for (let i = numberOfAlexaResponses; i > 0; i--) {
       expect(finalMessages[finalMessages.length - i]).toEqual(

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -161,16 +161,14 @@ it("handles the user's form submission with request to Alexa and populates the s
   const alexaId = chatterIds.ALEXA;
   const alexa = chatters.get(alexaId);
 
-  let expectedAlexaResponses = List();
-  for (let alexaResponse of mockAlexaSuccessResponses) {
-    expectedAlexaResponses = expectedAlexaResponses.push(
+  const expectedAlexaResponses = mockAlexaSuccessResponses.map(
+    alexaResponse =>
       new Message({
         id: alexaId,
         message: alexaResponse,
         senderName: alexa.name
       })
-    );
-  }
+  );
 
   testOnUserRequestToAlexaSubmitHandling(
     authenticationInfo,

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
-const { List } = require("immutable");
+const { List, fromJS } = require("immutable");
 
 import { ChatFeed, Message } from "react-chat-ui";
 import ChatWindow from "./ChatWindow";
@@ -308,14 +308,12 @@ const testOnUserRequestToAlexaSubmitHandling = (
     expect(finalMessages.length).toBe(
       numberOfMessagesAlreadyInState + numberOfNewMessagesToGoIntoState
     );
+    expect(finalMessages[numberOfMessagesAlreadyInState]).toEqual(
+      expectedUserMessage
+    );
     expect(
-      finalMessages[finalMessages.length - numberOfNewMessagesToGoIntoState]
-    ).toEqual(expectedUserMessage);
-    for (let i = numberOfExpectedAlexaResponses; i > 0; i--) {
-      expect(finalMessages[finalMessages.length - i]).toEqual(
-        expectedAlexaResponses.get(numberOfExpectedAlexaResponses - i)
-      );
-    }
+      fromJS(finalMessages.slice(numberOfMessagesAlreadyInState + 1))
+    ).toEqual(expectedAlexaResponses);
 
     expect(chatWindowInstance.state.userRequestToAlexa).toEqual("");
     done();

--- a/src/SpeakDirectiveParser.js
+++ b/src/SpeakDirectiveParser.js
@@ -1,8 +1,8 @@
 import IllegalArgumentError from "./errors/IllegalArgumentError";
 
-const httpMessageParser = require("http-message-parser");
-const { List, hasIn } = require("immutable");
-const util = require("util");
+import { List, hasIn } from "immutable";
+import util from "util";
+import httpMessageParser from "http-message-parser";
 
 /**
  * This method parses the multi-part AVS responses and extracts the

--- a/src/SpeakDirectiveParser.test.js
+++ b/src/SpeakDirectiveParser.test.js
@@ -1,4 +1,4 @@
-import { extractAlexaTextResponse } from "./SpeakDirectiveParser";
+import { extractAlexaTextResponse as parser } from "./SpeakDirectiveParser";
 import IllegalArgumentError from "./errors/IllegalArgumentError";
 
 import testData from "./test-data/multipart-response-test-data";
@@ -46,21 +46,21 @@ it("handles the invalid case where the directive in the AVS response is well for
 it("handles the case where the multi-part message has three parts (because, the happy case is two parts)", () => {
   const testObject = testData.multi_part_with_just_three_parts;
 
-  const alexaTextResponse = extractAlexaTextResponse(testObject.rawData);
+  const alexaTextResponse = parser(testObject.rawData);
   expect(alexaTextResponse).toEqual(testObject.alexaResponse);
 });
 
 it("extracts Alexa's response in the happy case", () => {
   const testObject = testData.happy_case;
 
-  const alexaTextResponse = extractAlexaTextResponse(testObject.rawData);
+  const alexaTextResponse = parser(testObject.rawData);
   expect(alexaTextResponse).toEqual(testObject.alexaResponse);
 });
 
 it("handles gracefully when Alexa doesn't say anything in response. For ex, when user says 'stop'", () => {
   const testObject = testData.happy_case_when_alexa_chooses_to_say_nothing;
 
-  const alexaTextResponse = extractAlexaTextResponse(testObject.rawData);
+  const alexaTextResponse = parser(testObject.rawData);
   expect(alexaTextResponse).toEqual(testObject.alexaResponse);
 });
 
@@ -70,6 +70,6 @@ it("handles gracefully when Alexa doesn't say anything in response. For ex, when
  */
 const testIllegalArgumentHandling = input => {
   expect(() => {
-    extractAlexaTextResponse(input);
+    parser(input);
   }).toThrow(IllegalArgumentError);
 };

--- a/src/SpeakDirectiveParser.test.js
+++ b/src/SpeakDirectiveParser.test.js
@@ -43,25 +43,32 @@ it("handles the invalid case where the directive in the AVS response is well for
   );
 });
 
-it("handles the case where the multi-part message has three parts (because, the happy case is two parts)", () => {
+it("does not include non-text parts in Alexa's response", () => {
+  const testObject = testData.multi_part_with_different_content_types;
+
+  const alexaTextResponses = extractAlexaTextResponses(testObject.rawData);
+  expect(alexaTextResponses).toEqual(testObject.alexaResponses);
+});
+
+it("handles the case where Alexa's text response is broken into more than one part", () => {
   const testObject = testData.multi_part_with_just_three_parts;
 
   const alexaTextResponse = parser(testObject.rawData);
-  expect(alexaTextResponse).toEqual(testObject.alexaResponse);
+  expect(alexaTextResponses).toEqual(testObject.alexaResponses);
 });
 
 it("extracts Alexa's response in the happy case", () => {
   const testObject = testData.happy_case;
 
   const alexaTextResponse = parser(testObject.rawData);
-  expect(alexaTextResponse).toEqual(testObject.alexaResponse);
+  expect(alexaTextResponses).toEqual(testObject.alexaResponses);
 });
 
 it("handles gracefully when Alexa doesn't say anything in response. For ex, when user says 'stop'", () => {
   const testObject = testData.happy_case_when_alexa_chooses_to_say_nothing;
 
   const alexaTextResponse = parser(testObject.rawData);
-  expect(alexaTextResponse).toEqual(testObject.alexaResponse);
+  expect(alexaTextResponses).toEqual(testObject.alexaResponses);
 });
 
 /**

--- a/src/__mocks__/AVSGateway.js
+++ b/src/__mocks__/AVSGateway.js
@@ -1,11 +1,17 @@
-export const mockAlexaSuccessResponse = "mock alexa success response";
+const { List } = require("immutable");
+
+export const mockAlexaSuccessResponses = List.of(
+  "mock alexa success response 1",
+  "mock alexa success response 2",
+  "mock alexa success response 3"
+);
 
 // Mock implementation that always resolves to a successful response from AVS.
 export const mockSendTextMessageEventFunction = jest.fn(() =>
-  Promise.resolve(mockAlexaSuccessResponse)
+  Promise.resolve(mockAlexaSuccessResponses)
 );
 
-const mockAVSGateway = jest.fn().mockImplementation(() => {
+const mockAVSGateway = jest.fn(() => {
   return { sendTextMessageEvent: mockSendTextMessageEventFunction };
 });
 

--- a/src/test-data/multipart-response-test-data.js
+++ b/src/test-data/multipart-response-test-data.js
@@ -1,3 +1,5 @@
+const { List } = require("immutable");
+
 // Invalid case where multi-part message has just one part. This should never happen in real world.
 {
   const rawData = String.raw`--------abcde123
@@ -125,7 +127,7 @@ third-part-of-multi-part-message
 
   exports.multi_part_with_just_three_parts = {
     rawData: rawData,
-    alexaResponse: alexaResponse
+    alexaResponse: List.of(alexaResponse)
   };
 }
 
@@ -145,7 +147,7 @@ second-part-of-multi-part-message
 
   exports.happy_case = {
     rawData: rawData,
-    alexaResponse: alexaResponse
+    alexaResponse: List.of(alexaResponse)
   };
 }
 
@@ -165,6 +167,6 @@ second-part-of-multi-part-message
 
   exports.happy_case_when_alexa_chooses_to_say_nothing = {
     rawData: rawData,
-    alexaResponse: alexaResponse
+    alexaResponse: List.of(alexaResponse)
   };
 }

--- a/src/test-data/multipart-response-test-data.js
+++ b/src/test-data/multipart-response-test-data.js
@@ -97,7 +97,7 @@ Content-Type: application/json; charset=UTF-8
 Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
 Content-Type: application/octet-stream
 
-second-part-of-multi-part-message
+first-part-of-multi-part-message
 --------abcde123--`;
 
   exports.caption_key_doesnt_exist_in_avs_directive = {
@@ -105,29 +105,72 @@ second-part-of-multi-part-message
   };
 }
 
-// A multi-part message with three parts. Each of the parts is valid.
-// Important to test this because usually multi-part messages from AVS have two parts but sometimes more.
+// A multi-part message with multiple parts where one part is a valid text response from Alexa and others are either valid non-text responses or parts whose Content-Type is not known.
 {
+  const validTextResponseContentType = "application/json; charset=UTF-8";
+  const validNonTextResponseContentType = "application/octet-stream";
+  const emptyContentType = "";
+  let missingContentType;
+
   const alexaResponse = "alexa success response";
   const rawData = String.raw`--------abcde123
-Content-Type: application/json; charset=UTF-8
+Content-Type: ${validTextResponseContentType}
 
 {"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"${alexaResponse}","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">${alexaResponse}</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
 --------abcde123
 Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
-Content-Type: application/octet-stream
+Content-Type: ${validNonTextResponseContentType}
 
 second-part-of-multi-part-message
 --------abcde123
 Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
-Content-Type: application/octet-stream
+Content-Type: ${emptyContentType}
 
 third-part-of-multi-part-message
+--------abcde123--
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: ${missingContentType}
+
+fourth-part-of-multi-part-message
+--------abcde123--
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+
+fifth-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.multi_part_with_different_content_types = {
+    rawData: rawData,
+    alexaResponses: List.of(alexaResponse)
+  };
+}
+
+// A multi-part message with multiple valid parts where the text and audio response from Alexa is contained in those parts.
+{
+  const alexaResponseFirstPart = "alexa success response first part";
+  const alexaResponseSecondPart = "alexa success response second part";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"${alexaResponseFirstPart}","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">${alexaResponseFirstPart}</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+first-audio-part-of-multi-part-message
+--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"${alexaResponseSecondPart}","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">${alexaResponseSecondPart}</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-audio-part-of-multi-part-message
 --------abcde123--`;
 
   exports.multi_part_with_just_three_parts = {
     rawData: rawData,
-    alexaResponse: List.of(alexaResponse)
+    alexaResponses: List.of(alexaResponseFirstPart, alexaResponseSecondPart)
   };
 }
 
@@ -147,7 +190,7 @@ second-part-of-multi-part-message
 
   exports.happy_case = {
     rawData: rawData,
-    alexaResponse: List.of(alexaResponse)
+    alexaResponses: List.of(alexaResponse)
   };
 }
 
@@ -167,6 +210,6 @@ second-part-of-multi-part-message
 
   exports.happy_case_when_alexa_chooses_to_say_nothing = {
     rawData: rawData,
-    alexaResponse: List.of(alexaResponse)
+    alexaResponses: List.of(alexaResponse)
   };
 }


### PR DESCRIPTION
Alexa can return her response in multiple parts. Previously, we
assumed that the parts are text and audio responses. However, as
noted in the above issue, the text itself can be broken into
multiple parts.

In the current code, since we assume that there is only one text
part, we end up showing only the first part in her multi-part
response message.

This is a preparatory commit that changes the interfaces between
ChatWindow / AVSGateway / SpeakDirectiveParser to be list of responses
instead of a single response string. There is no behavior change in
this commit besides the interface change.