### PR TITLE
Reverting to http-message-parser v0.0.22 because the latest version cannot be minified.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://s-maheshbabu.github.io/silent-alexa",
   "dependencies": {
     "gh-pages": "^1.1.0",
-    "http-message-parser": "0.0.28",
+    "http-message-parser": "0.0.22",
     "immutable": "^4.0.0-rc.9",
     "material-ui": "^0.20.0",
     "npm": "^5.8.0",
@@ -33,8 +33,6 @@
     "sprintf-js": "^1.1.1"
   },
   "jest": {
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
+    "snapshotSerializers": ["enzyme-to-json/serializer"]
   }
 }


### PR DESCRIPTION
Filed an issue for the developer to see if they can publish
as ES5.
https://github.com/miguelmota/http-message-parser/issues/5

We can upgrade if the developer agrees to publish as ES5.
Otherwise, will fork it.

