### PR TITLE
Moving to absolute imports instead of relative imports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "start": "react-scripts start",
+    "start": "NODE_PATH=src react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "test": "NODE_PATH=src react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
   "devDependencies": {

--- a/src/AVSGateway.js
+++ b/src/AVSGateway.js
@@ -1,9 +1,9 @@
-import { urls, paths } from "./AVSEndPoints";
-import { cannedErrorResponses, customErrorCodes } from "./CannedErrorResponses";
-import { cannedResponses } from "./CannedResponses";
+import { urls, paths } from "AVSEndPoints";
+import { cannedErrorResponses, customErrorCodes } from "CannedErrorResponses";
+import { cannedResponses } from "CannedResponses";
 
-import IllegalArgumentError from "./errors/IllegalArgumentError";
-import { extractAlexaTextResponses as parser } from "./SpeakDirectiveParser";
+import IllegalArgumentError from "errors/IllegalArgumentError";
+import { extractAlexaTextResponses as parser } from "SpeakDirectiveParser";
 
 import { hasIn, List } from "immutable";
 import uuid from "uuid/v4";

--- a/src/AVSGateway.test.js
+++ b/src/AVSGateway.test.js
@@ -1,31 +1,30 @@
 import React from "react";
 import { List } from "immutable";
 
-import AVSGateway from "./AVSGateway";
-import { EVENTS_URL } from "./AVSGateway";
-import IllegalArgumentError from "./errors/IllegalArgumentError";
+import AVSGateway, { EVENTS_URL } from "./AVSGateway";
+import IllegalArgumentError from "errors/IllegalArgumentError";
 
-import { cannedErrorResponses, customErrorCodes } from "./CannedErrorResponses";
-import { cannedResponses } from "./CannedResponses";
+import { cannedErrorResponses, customErrorCodes } from "CannedErrorResponses";
+import { cannedResponses } from "CannedResponses";
 
-import testData from "./test-data/multipart-response-test-data";
+import testData from "test-data/multipart-response-test-data";
 
 // A mock parser that uses the real implementation by default.
-jest.mock("./SpeakDirectiveParser", () => {
+jest.mock("SpeakDirectiveParser", () => {
   return {
     extractAlexaTextResponses: jest.fn(
-      require.requireActual("./SpeakDirectiveParser").extractAlexaTextResponses
+      require.requireActual("SpeakDirectiveParser").extractAlexaTextResponses
     )
   };
 });
-const parser = require("./SpeakDirectiveParser");
+const parser = require("SpeakDirectiveParser");
 
 jest.mock("uuid/v4", () => {
   return jest.fn(() => "mock-uuid-generated-for-testing");
 });
-const uuid = require("uuid/v4");
+import uuid from "uuid/v4";
 
-const fetchMock = require("fetch-mock");
+import fetchMock from "fetch-mock";
 
 const unitUnderTest = new AVSGateway();
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,11 @@
 import React, { Component } from "react";
-import "./App.css";
+import "App.css";
 import util from "util";
 
-import Header from "./Header";
-import Body from "./Body";
-import Footer from "./Footer";
-import AuthenticationInfo from "./AuthenticationInfo";
+import Header from "Header";
+import Body from "Body";
+import Footer from "Footer";
+import AuthenticationInfo from "AuthenticationInfo";
 
 class App extends Component {
   constructor(props) {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import App from "./App";
-import AuthenticationInfo from "./AuthenticationInfo";
+import App from "App";
+import AuthenticationInfo from "AuthenticationInfo";
 
 let app;
 let appInstance;

--- a/src/AuthenticationInfo.js
+++ b/src/AuthenticationInfo.js
@@ -1,4 +1,4 @@
-import IllegalArgumentError from "./errors/IllegalArgumentError";
+import IllegalArgumentError from "errors/IllegalArgumentError";
 import util from "util";
 
 /**

--- a/src/AuthenticationInfo.test.js
+++ b/src/AuthenticationInfo.test.js
@@ -1,5 +1,5 @@
-import AuthenticationInfo from "./AuthenticationInfo";
-import IllegalArgumentError from "./errors/IllegalArgumentError";
+import AuthenticationInfo from "AuthenticationInfo";
+import IllegalArgumentError from "errors/IllegalArgumentError";
 
 it("verifes that instance is created if lwaResponse has all the required fields", () => {
   const lwaResponse = {

--- a/src/Body.js
+++ b/src/Body.js
@@ -1,8 +1,8 @@
 import React from "react";
 import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
-import ChatWindow from "./ChatWindow";
-import RightPanel from "./RightPanel";
-import WelcomeScreen from "./WelcomeScreen";
+import ChatWindow from "ChatWindow";
+import RightPanel from "RightPanel";
+import WelcomeScreen from "WelcomeScreen";
 
 export default function Body(props) {
   if (props.isAuthenticationInfoValid()) {

--- a/src/Body.test.js
+++ b/src/Body.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
-import Body from "./Body";
+import Body from "Body";
 
 const mockIsAuthenticationInfoValid = jest.fn();
 

--- a/src/ChatBubble.js
+++ b/src/ChatBubble.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { ChatBubble } from "react-chat-ui";
 
-import styles from "./ChatBubble.css.js";
+import styles from "ChatBubble.css.js";
 
 export default function(props) {
   return (

--- a/src/ChatBubble.test.js
+++ b/src/ChatBubble.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import ChatBubble from "./ChatBubble";
+import ChatBubble from "ChatBubble";
 
 it("renders correctly (snapshot testing)", () => {
   const wrapper = shallow(<ChatBubble />);

--- a/src/ChatWindow.js
+++ b/src/ChatWindow.js
@@ -2,15 +2,15 @@ import React, { Component } from "react";
 import { ChatFeed, Message } from "react-chat-ui";
 import ContainerDimensions from "react-container-dimensions";
 
-import ChatBubble from "./ChatBubble";
-import { cannedErrorResponses, customErrorCodes } from "./CannedErrorResponses";
+import ChatBubble from "ChatBubble";
+import { cannedErrorResponses, customErrorCodes } from "CannedErrorResponses";
 
-import UserRequestToAlexaForm from "./UserRequestToAlexaForm";
-import "./ChatWindow.css";
+import UserRequestToAlexaForm from "UserRequestToAlexaForm";
+import "ChatWindow.css";
 
-import { chatters, chatterIds } from "./Chatters";
+import { chatters, chatterIds } from "Chatters";
 
-import AVSGateway from "./AVSGateway";
+import AVSGateway from "AVSGateway";
 const avs = new AVSGateway();
 
 class ChatWindow extends Component {

--- a/src/ChatWindow.test.js
+++ b/src/ChatWindow.test.js
@@ -3,16 +3,16 @@ import { shallow, mount } from "enzyme";
 const { List, fromJS } = require("immutable");
 
 import { ChatFeed, Message } from "react-chat-ui";
-import ChatWindow from "./ChatWindow";
-import { cannedErrorResponses, customErrorCodes } from "./CannedErrorResponses";
-import AuthenticationInfo from "./AuthenticationInfo";
+import ChatWindow from "ChatWindow";
+import { cannedErrorResponses, customErrorCodes } from "CannedErrorResponses";
+import AuthenticationInfo from "AuthenticationInfo";
 
 import {
   mockSendTextMessageEventFunction,
   mockAlexaSuccessResponses
-} from "./AVSGateway";
+} from "AVSGateway";
 
-import { chatters, chatterIds } from "./Chatters";
+import { chatters, chatterIds } from "Chatters";
 
 const CHATFEED_CONTAINER_HEIGHT = 234;
 const CHATFEED_CONTAINER_HEIGHT_DEFAULT = 0;

--- a/src/Chatters.test.js
+++ b/src/Chatters.test.js
@@ -1,4 +1,4 @@
-import { chatters, chatterIds } from "./Chatters";
+import { chatters, chatterIds } from "Chatters";
 
 test("that all chatterIds are contained in the map and that all chatters in the map are represented in the chatterIds", () => {
   expect(Object.keys(chatterIds).length).toEqual(

--- a/src/Footer.test.js
+++ b/src/Footer.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Footer from "./Footer";
+import Footer from "Footer";
 
 it("renders Footer without crashing", () => {
   const wrapper = shallow(<Footer />);

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,6 +1,6 @@
 import React from "react";
-import "./Header.css";
-import LoginControl from "./LoginControl";
+import "Header.css";
+import LoginControl from "LoginControl";
 
 export default function Header(props) {
   return (

--- a/src/Header.test.js
+++ b/src/Header.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Header from "./Header";
+import Header from "Header";
 
 it("renders Header without crashing", () => {
   const wrapper = shallow(<Header />);

--- a/src/LoginButton.test.js
+++ b/src/LoginButton.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import LoginButton from "./LoginButton";
+import LoginButton from "LoginButton";
 
 it("renders LoginButton without crashing", () => {
   const wrapper = shallow(<LoginButton />);

--- a/src/LoginControl.js
+++ b/src/LoginControl.js
@@ -1,7 +1,7 @@
 import React from "react";
-import LoginButton from "./LoginButton";
-import LogoutButton from "./LogoutButton";
-import AuthenticationInfo from "./AuthenticationInfo";
+import LoginButton from "LoginButton";
+import LogoutButton from "LogoutButton";
+import AuthenticationInfo from "AuthenticationInfo";
 import util from "util";
 
 // Options variable to request for implicit grant.

--- a/src/LoginControl.test.js
+++ b/src/LoginControl.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
-import { options, default as LoginControl } from "./LoginControl";
-import AuthenticationInfo from "./AuthenticationInfo";
+import { options, default as LoginControl } from "LoginControl";
+import AuthenticationInfo from "AuthenticationInfo";
 import util from "util";
 
 let loginControl;

--- a/src/LogoutButton.test.js
+++ b/src/LogoutButton.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
-import LogoutButton from "./LogoutButton";
+import LogoutButton from "LogoutButton";
 
 it("renders correctly (snapshot testing)", () => {
   const wrapper = shallow(<LogoutButton />);

--- a/src/RightPanel.test.js
+++ b/src/RightPanel.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import RightPanel from "./RightPanel";
+import RightPanel from "RightPanel";
 
 it("renders RightPanel without crashing", () => {
   const wrapper = shallow(<RightPanel />);

--- a/src/SpeakDirectiveParser.js
+++ b/src/SpeakDirectiveParser.js
@@ -1,4 +1,4 @@
-import IllegalArgumentError from "./errors/IllegalArgumentError";
+import IllegalArgumentError from "errors/IllegalArgumentError";
 
 import { hasIn, getIn, fromJS } from "immutable";
 import util from "util";

--- a/src/SpeakDirectiveParser.test.js
+++ b/src/SpeakDirectiveParser.test.js
@@ -1,7 +1,7 @@
-import { extractAlexaTextResponses as parser } from "./SpeakDirectiveParser";
-import IllegalArgumentError from "./errors/IllegalArgumentError";
+import { extractAlexaTextResponses as parser } from "SpeakDirectiveParser";
+import IllegalArgumentError from "errors/IllegalArgumentError";
 
-import testData from "./test-data/multipart-response-test-data";
+import testData from "test-data/multipart-response-test-data";
 
 it("throws an error if an empty string is passed as input", () => {
   const input = "";

--- a/src/UserRequestToAlexaForm.js
+++ b/src/UserRequestToAlexaForm.js
@@ -2,11 +2,11 @@ import React from "react";
 import TextField from "material-ui/TextField";
 import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
 
-const DEFAULT_PLACEHOLDER_VALUE = require("./Constants");
+import DEFAULT_PLACEHOLDER_VALUE from "./Constants";
+
 /*
 The input component where user's type in their requests for Alexa
 */
-
 const UserRequestToAlexaForm = props => {
   return (
     <form onSubmit={e => props.onSubmit(e)}>

--- a/src/UserRequestToAlexaForm.test.js
+++ b/src/UserRequestToAlexaForm.test.js
@@ -5,7 +5,7 @@ import ChatWindow from "ChatWindow";
 import UserRequestToAlexaForm from "UserRequestToAlexaForm";
 import TextField from "material-ui/TextField";
 
-const DEFAULT_PLACEHOLDER_VALUE = require("Constants");
+import DEFAULT_PLACEHOLDER_VALUE from "./Constants";
 
 it("renders UserRequestToAlexaForm without crashing", () => {
   const wrapper = shallow(<UserRequestToAlexaForm />);

--- a/src/UserRequestToAlexaForm.test.js
+++ b/src/UserRequestToAlexaForm.test.js
@@ -1,11 +1,11 @@
 import React from "react";
 import { mount, shallow } from "enzyme";
 
-import ChatWindow from "./ChatWindow";
-import UserRequestToAlexaForm from "./UserRequestToAlexaForm";
+import ChatWindow from "ChatWindow";
+import UserRequestToAlexaForm from "UserRequestToAlexaForm";
 import TextField from "material-ui/TextField";
 
-const DEFAULT_PLACEHOLDER_VALUE = require("./Constants");
+const DEFAULT_PLACEHOLDER_VALUE = require("Constants");
 
 it("renders UserRequestToAlexaForm without crashing", () => {
   const wrapper = shallow(<UserRequestToAlexaForm />);

--- a/src/WelcomeScreen.test.js
+++ b/src/WelcomeScreen.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import WelcomeScreen from "./WelcomeScreen";
+import WelcomeScreen from "WelcomeScreen";
 
 it("renders without crashing", () => {
   const wrapper = shallow(<WelcomeScreen />);

--- a/src/__mocks__/AVSGateway.js
+++ b/src/__mocks__/AVSGateway.js
@@ -1,4 +1,4 @@
-const { List } = require("immutable");
+import { List } from "immutable";
 
 export const mockAlexaSuccessResponses = List.of(
   "mock alexa success response 1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import "./index.css";
-import App from "./App";
-import registerServiceWorker from "./registerServiceWorker";
+import "index.css";
+import App from "App";
+import registerServiceWorker from "registerServiceWorker";
 
 ReactDOM.render(<App />, document.getElementById("root"));
 registerServiceWorker();


### PR DESCRIPTION
This is in preparation to a file organization refactor.
Using absolute imports will let us organize the project
into folders without having to worry about the import
paths.

Note: AVSGateway.test.js will still use relative paths because
there is a mock under __mocks__/AVSGateway.js which will
precedence if we use absolute paths. When there is a mock
with the same name (btw, jest needs the names of mocks to
be the same), I think we have to live with relative import in the
test file.