### PR TITLE
Tightening the tests around Chatters.

### DIFF
--- a/src/constants/Chatters.js
+++ b/src/constants/Chatters.js
@@ -1,7 +1,3 @@
-/*
-TODO: Improve Chatters tests. Current tests don't fail if the properties
-of a chatter (like their name or avatar) are changed.
-*/
 import React from "react";
 import { Map } from "immutable";
 import AlexaRingIcon from "Icons/AlexaRingIcon";

--- a/src/constants/Chatters.test.js
+++ b/src/constants/Chatters.test.js
@@ -1,4 +1,10 @@
+import React from "react";
 import { chatters, chatterIds } from "Chatters";
+import AlexaRingIcon from "Icons/AlexaRingIcon";
+
+test("that there are only two chatters.", () => {
+  expect(Object.keys(chatterIds).length).toEqual(2);
+});
 
 test("that all chatterIds are contained in the map and that all chatters in the map are represented in the chatterIds", () => {
   expect(Object.keys(chatterIds).length).toEqual(
@@ -9,4 +15,16 @@ test("that all chatterIds are contained in the map and that all chatters in the 
     const chatter = chatters.get(chatterId);
     expect(chatter).toBeDefined();
   });
+});
+
+test("that USER is configured correctly", () => {
+  const user = chatters.get(chatterIds.USER);
+  expect(user.name).toBe("You");
+  expect(user.avatar).toBeUndefined();
+});
+
+test("that ALEXA is configured correctly", () => {
+  const alexa = chatters.get(chatterIds.ALEXA);
+  expect(alexa.name).toBeUndefined();
+  expect(alexa.avatar).toEqual(<AlexaRingIcon />);
 });


### PR DESCRIPTION
Since the contents of Chatters (like name and avatar) can control what gets displayed
on the UI, it is important to have tighter tests.

Added such tests to make sure chatters can't get added or deleted or the attributes
of chatters can't be changed without the tests breaking. 