### PR TITLE
Added Routes to support "redirect_uri" for LoginWithAmazon.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5245,6 +5245,18 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
+    "history": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+      "requires": {
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7639,6 +7651,17 @@
         "prepend-http": "1.0.4",
         "query-string": "4.3.4",
         "sort-keys": "1.1.2"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "requires": {
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        }
       }
     },
     "npm": {
@@ -13298,10 +13321,11 @@
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
+        "decode-uri-component": "0.2.0",
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
       }
@@ -13527,6 +13551,89 @@
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
         "prop-types": "15.6.0"
+      }
+    },
+    "react-router": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "requires": {
+        "history": "4.7.2",
+        "hoist-non-react-statics": "2.5.0",
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.1",
+        "warning": "4.0.1"
+      },
+      "dependencies": {
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "warning": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
+          "integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
+      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "requires": {
+        "history": "4.7.2",
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.1",
+        "react-router": "4.3.1",
+        "warning": "4.0.1"
+      },
+      "dependencies": {
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "warning": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
+          "integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        }
       }
     },
     "react-scripts": {
@@ -13966,6 +14073,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+    },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -15425,6 +15537,11 @@
         "spdx-correct": "3.0.0",
         "spdx-expression-parse": "3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "react": "^16.2.0",
     "react-container-dimensions": "^1.3.3",
     "react-dom": "^16.2.0",
+    "react-router-dom": "^4.2.2",
+    "query-string": "^5.1.1",
     "react-scripts": "1.1.4",
     "uuid": "^3.2.1"
   },

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,6 +5,7 @@ import util from "util";
 import Header from "Header/Header";
 import Body from "Body/Body";
 import Footer from "Footer/Footer";
+import Routes from "Routes/Routes";
 import AuthenticationInfo from "AuthenticationInfo";
 
 class App extends Component {
@@ -17,12 +18,14 @@ class App extends Component {
   render() {
     return (
       <div id="page">
-        <Header
-          isAuthenticationInfoValid={() => this.isAuthenticationInfoValid()}
-          clearAuthenticationInfo={() => this.clearAuthenticationInfo()}
+        <Routes
           updateAuthenticationInfo={authenticationInfo =>
             this.updateAuthenticationInfo(authenticationInfo)
           }
+        />
+        <Header
+          isAuthenticationInfoValid={() => this.isAuthenticationInfoValid()}
+          clearAuthenticationInfo={() => this.clearAuthenticationInfo()}
         />
         <Body
           authenticationInfo={this.state.authenticationInfo}

--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -63,17 +63,7 @@ it("verifies that props are passed to Body component", () => {
 
 it("verifies that props are passed to Header component", () => {
   //Verify that Header receives desired number of props
-  expect(Object.keys(app.find("Header").props()).length).toBe(3);
-
-  // Verify that Header receives updateAuthenticationInfo prop
-  const updateAuthenticationInfoProp = app
-    .find("Header")
-    .prop("updateAuthenticationInfo");
-
-  // Verify that calling header's updateAuthenticationInfo prop calls updateAuthenticationInfo
-  const dummyArgument = "dummyArgument";
-  updateAuthenticationInfoProp(dummyArgument);
-  expect(updateAuthenticationInfoSpy).toHaveBeenCalledWith(dummyArgument);
+  expect(Object.keys(app.find("Header").props()).length).toBe(2);
 
   // Verify that Header receives clearAuthenticationInfo prop
   const clearAuthenticationInfoProp = app
@@ -92,6 +82,21 @@ it("verifies that props are passed to Header component", () => {
   // Verify that calling header's isAuthenticationInfoValid prop calls isAuthenticationInfoValid
   isAuthenticationInfoValidProp();
   expect(isAuthenticationInfoValidSpy).toHaveBeenCalledTimes(1);
+});
+
+it("verifies that props are passed to Routes component", () => {
+  //Verify that Router receives desired number of props
+  expect(Object.keys(app.find("Routes").props()).length).toBe(1);
+
+  // Verify that Router receives updateAuthenticationInfo prop
+  const updateAuthenticationInfoProp = app
+    .find("Routes")
+    .prop("updateAuthenticationInfo");
+
+  // Verify that calling router's updateAuthenticationInfo prop calls updateAuthenticationInfo
+  const dummyArgument = "dummyArgument";
+  updateAuthenticationInfoProp(dummyArgument);
+  expect(updateAuthenticationInfoSpy).toHaveBeenCalledWith(dummyArgument);
 });
 
 it("should not change state's authenticationInfo prop when authenticationInfo instance (implicit grant) is not valid", () => {

--- a/src/components/App/__snapshots__/App.test.js.snap
+++ b/src/components/App/__snapshots__/App.test.js.snap
@@ -4,10 +4,12 @@ exports[`renders correctly without crashing 1`] = `
 <div
   id="page"
 >
+  <Routes
+    updateAuthenticationInfo={[Function]}
+  />
   <Header
     clearAuthenticationInfo={[Function]}
     isAuthenticationInfoValid={[Function]}
-    updateAuthenticationInfo={[Function]}
   />
   <Body
     clearAuthenticationInfo={[Function]}

--- a/src/components/DefaultRedirect/DefaultRedirect.js
+++ b/src/components/DefaultRedirect/DefaultRedirect.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default class DefaultRedirect extends React.Component {
+  render() {
+    return null;
+  }
+
+  componentWillMount() {
+    if (this.props.history) {
+      this.props.history.push("/");
+    }
+  }
+}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -10,9 +10,6 @@ function _LoginControlInHeader(props) {
     <LoginControl
       isAuthenticationInfoValid={() => props.isAuthenticationInfoValid()}
       clearAuthenticationInfo={() => props.clearAuthenticationInfo()}
-      updateAuthenticationInfo={authenticationInfo =>
-        props.updateAuthenticationInfo(authenticationInfo)
-      }
     />
   );
 }

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -14,12 +14,10 @@ it("renders Header without crashing", () => {
 it("verifies that props are passed to LoginControl component", () => {
   const mockIsAuthenticationInfoValid = jest.fn();
   const mockClearAuthenticationInfo = jest.fn();
-  const mockUpdateAuthenticationInfo = jest.fn();
   const header = shallow(
     <Header
       isAuthenticationInfoValid={mockIsAuthenticationInfoValid}
       clearAuthenticationInfo={mockClearAuthenticationInfo}
-      updateAuthenticationInfo={mockUpdateAuthenticationInfo}
     />
   );
   const loginControl = header
@@ -28,7 +26,7 @@ it("verifies that props are passed to LoginControl component", () => {
     .prop("iconElementRight");
 
   // Verify that only desired number of props are passed on to LoginControl
-  expect(Object.keys(loginControl.props).length).toBe(3);
+  expect(Object.keys(loginControl.props).length).toBe(2);
 
   // Verify that LoginControl is passed on isAuthenticationInfoValid prop
   const isAuthenticationInfoValidProp =
@@ -47,15 +45,4 @@ it("verifies that props are passed to LoginControl component", () => {
   // Verify that calling clearAuthenticationInfo prop function calls the mockClearAuthenticationInfo
   clearAuthenticationInfoProp();
   expect(mockClearAuthenticationInfo).toHaveBeenCalledTimes(1);
-
-  // Verify that LoginControl is passed on updateAuthenticationInfo prop
-  const updateAuthenticationInfoProp =
-    loginControl.props["updateAuthenticationInfo"];
-  expect(updateAuthenticationInfoProp).toBeDefined();
-
-  // Verify that calling updateAuthenticationInfo prop function calls the mockUpdateAuthenticationInfo
-  let dummyArgument = "dummy argument";
-  updateAuthenticationInfoProp(dummyArgument);
-
-  expect(mockUpdateAuthenticationInfo).toHaveBeenCalledWith(dummyArgument);
 });

--- a/src/components/Header/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__snapshots__/Header.test.js.snap
@@ -14,7 +14,6 @@ exports[`renders Header without crashing 1`] = `
           <LoginControl
             clearAuthenticationInfo={[Function]}
             isAuthenticationInfoValid={[Function]}
-            updateAuthenticationInfo={[Function]}
           />
         }
         showMenuIconButton={false}

--- a/src/components/LoginControl/LoginControl.js
+++ b/src/components/LoginControl/LoginControl.js
@@ -1,7 +1,5 @@
 import React from "react";
 import HeaderFlatButton from "HeaderFlatButton/HeaderFlatButton";
-import AuthenticationInfo from "AuthenticationInfo";
-import util from "util";
 
 // Options variable to request for implicit grant.
 // TODO: Logic for assigning 'deviceSerialNumber' needs to be revisited.
@@ -12,8 +10,12 @@ export const options = Object.freeze({
       productID: "Silent_Alexa",
       productInstanceAttributes: { deviceSerialNumber: "12345" }
     }
-  }
+  },
+  popup: false
 });
+
+// Redirect URI to handle the response from LoginWithAmazon
+export const redirectUri = "http://localhost:3000/authresponse";
 
 export default class LoginControl extends React.Component {
   render() {
@@ -29,36 +31,12 @@ export default class LoginControl extends React.Component {
   }
 
   handleLogin() {
-    // This returns an AuthorizeRequest object. After the request is complete, the object will
-    // contain properties detailing the response
-    window.amazon.Login.authorize(options, response =>
-      this.handleLWAResponse(response)
-    );
+    // The authorization service will redirect the user-agent to redirectURI
+    // which will contain an authorization response as a URI fragment
+    window.amazon.Login.authorize(options, redirectUri);
   }
 
   handleLogout() {
     this.props.clearAuthenticationInfo();
-  }
-
-  handleLWAResponse = lwaResponse => {
-    // Call updateAuthenticationInfo only if lwaResponse is valid
-    if (this.isLWAResponseValid(lwaResponse)) {
-      this.props.updateAuthenticationInfo(new AuthenticationInfo(lwaResponse));
-    }
-  };
-
-  /**
-   * @returns true if LoginWithAmazon response is valid
-   *          false, otherwise.
-   */
-  isLWAResponseValid(lwaResponse) {
-    if (lwaResponse && lwaResponse.access_token && lwaResponse.expires_in) {
-      return true;
-    }
-    console.log(
-      "Encountered an error on login: " +
-        util.inspect(lwaResponse, { showHidden: true, depth: null })
-    );
-    return false;
   }
 }

--- a/src/components/LoginControl/LoginControl.test.js
+++ b/src/components/LoginControl/LoginControl.test.js
@@ -1,12 +1,11 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
-import { options, default as LoginControl } from "./LoginControl";
+import { options, redirectUri, default as LoginControl } from "./LoginControl";
 import AuthenticationInfo from "AuthenticationInfo";
 import util from "util";
 
 let loginControl;
 let loginControlInstance;
-const mockUpdateAuthenticationInfo = jest.fn();
 const mockClearAuthenticationInfo = jest.fn();
 const mockLWAModule = jest.fn();
 const mockIsAuthenticationInfoValid = jest.fn();
@@ -21,7 +20,6 @@ beforeEach(() => {
     <LoginControl
       isAuthenticationInfoValid={mockIsAuthenticationInfoValid}
       clearAuthenticationInfo={mockClearAuthenticationInfo}
-      updateAuthenticationInfo={mockUpdateAuthenticationInfo}
     />
   );
   loginControlInstance = loginControl.instance();
@@ -94,67 +92,8 @@ it("verifies that clearAuthenticationInfo is called when handleLogout is called"
 
 it("verifies that lwa authorization is called when handleLogin is called", () => {
   loginControlInstance.handleLogin();
-  const handleLWAResponseSpy = jest.spyOn(
-    loginControlInstance,
-    "handleLWAResponse"
-  );
-  const dummyLWAResponse = "dummyLWAResponse";
 
   expect(mockLWAModule).toHaveBeenCalledTimes(1);
   expect(mockLWAModule.mock.calls[0][0]).toBe(options);
-  const lwaCallback = mockLWAModule.mock.calls[0][1];
-  lwaCallback(dummyLWAResponse);
-  expect(handleLWAResponseSpy).toHaveBeenCalledWith(dummyLWAResponse);
-});
-
-it("verifies that updateAuthenticationInfo is called when handleLWAResponse is called with valid lwaResponse", () => {
-  const lwaResponse = {
-    access_token: "some_access_token",
-    expires_in: "30"
-  };
-
-  loginControlInstance.handleLWAResponse(lwaResponse);
-
-  expect(mockUpdateAuthenticationInfo).toHaveBeenCalledTimes(1);
-  const authenticationInfo = mockUpdateAuthenticationInfo.mock.calls[0][0];
-  expect(authenticationInfo.getAccessToken()).toBe(lwaResponse.access_token);
-});
-
-it("verifies that updateAuthenticationInfo is not called when handleLWAResponse is called with invalid lwaResponse", () => {
-  const lwaResponseWithEmptyAccessToken = {
-    access_token: "",
-    expires_in: "30"
-  };
-  const lwaResponseWithMissingAccessToken = {
-    expires_in: "30"
-  };
-  const lwaResponseWithMissingExpiresIn = {
-    access_token: "some_access_token"
-  };
-  const lwaResponseWithEmptyExpiresIn = {
-    access_token: "some_access_token",
-    expires_in: ""
-  };
-  const lwaReponseWithError = {
-    error: "some_error_code",
-    error_description: "description about error as string"
-  };
-  const lwaResponseEmpty = {};
-  let lwaResponseUndefined;
-
-  const invalidLWAResponseObjects = [
-    lwaResponseWithEmptyAccessToken,
-    lwaResponseWithMissingAccessToken,
-    lwaResponseWithEmptyExpiresIn,
-    lwaResponseWithMissingExpiresIn,
-    lwaReponseWithError,
-    lwaResponseEmpty,
-    lwaResponseUndefined
-  ];
-
-  for (let i = 0; i < invalidLWAResponseObjects.length; i++) {
-    loginControlInstance.handleLWAResponse(invalidLWAResponseObjects[i]);
-
-    expect(mockUpdateAuthenticationInfo).not.toHaveBeenCalled();
-  }
+  expect(mockLWAModule.mock.calls[0][1]).toBe(redirectUri);
 });

--- a/src/components/LoginHandler/LoginHandler.js
+++ b/src/components/LoginHandler/LoginHandler.js
@@ -1,0 +1,41 @@
+import React from "react";
+import queryString from "query-string";
+import util from "util";
+import AuthenticationInfo from "AuthenticationInfo";
+import { hasIn } from "immutable";
+
+export default class LoginHandler extends React.Component {
+  render() {
+    return null;
+  }
+
+  componentWillMount() {
+    let lwaResponse;
+    // Parses the query string to fetch the login with amazon response object
+    if (hasIn(this.props, ["location", "hash"])) {
+      lwaResponse = queryString.parse(this.props.location.hash);
+    }
+    if (this.isLWAResponseValid(lwaResponse)) {
+      this.props.updateAuthenticationInfo(new AuthenticationInfo(lwaResponse));
+    }
+
+    if (this.props.history) {
+      this.props.history.push("/");
+    }
+  }
+
+  /**
+   * @returns true if LoginWithAmazon response is valid
+   *          false, otherwise.
+   */
+  isLWAResponseValid(lwaResponse) {
+    if (lwaResponse && lwaResponse.access_token && lwaResponse.expires_in) {
+      return true;
+    }
+    console.log(
+      "Encountered an error on login: " +
+        util.inspect(lwaResponse, { showHidden: true, depth: null })
+    );
+    return false;
+  }
+}

--- a/src/components/LoginHandler/LoginHandler.test.js
+++ b/src/components/LoginHandler/LoginHandler.test.js
@@ -1,0 +1,90 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import LoginHandler from "./LoginHandler";
+import AuthenticationInfo from "AuthenticationInfo";
+import util from "util";
+
+let loginHandler;
+let loginHandlerInstance;
+const mockUpdateAuthenticationInfo = jest.fn();
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+it("renders LoginHandler without crashing", () => {
+  const wrapper = mount(<LoginHandler />);
+
+  expect(wrapper).toMatchSnapshot();
+
+  wrapper.unmount();
+});
+
+it("expects updateAuthenticationInfo to be called when LoginHandler is mounted", () => {
+  const lwaResponse = "access_token=some_access_token&expires_in=30";
+  const routeProps = { location: { hash: lwaResponse } };
+  const wrapper = mount(
+    <LoginHandler
+      updateAuthenticationInfo={mockUpdateAuthenticationInfo}
+      {...routeProps}
+    />
+  );
+
+  expect(mockUpdateAuthenticationInfo).toHaveBeenCalledTimes(1);
+  expect(
+    mockUpdateAuthenticationInfo.mock.calls[0][0].getAccessToken()
+  ).toEqual("some_access_token");
+
+  wrapper.unmount();
+});
+
+it("expects updateAuthenticationInfo to not be called when LoginHandler is mounted", () => {
+  const lwaResponse = "error_token=some_access_token&expires_in=30";
+  const routeProps = { location: { hash: lwaResponse } };
+  const routePropsNoLocation = { not_location: { hash: lwaResponse } };
+  const routePropsNoHash = { location: { not_hash: lwaResponse } };
+  const routePropsNoLwaResponse = { location: { hash: {} } };
+
+  const wrapperWithInvalidLwaResponse = mount(
+    <LoginHandler
+      updateAuthenticationInfo={mockUpdateAuthenticationInfo}
+      {...routeProps}
+    />
+  );
+  const wrapperWithNoRouteProps = mount(
+    <LoginHandler updateAuthenticationInfo={mockUpdateAuthenticationInfo} />
+  );
+
+  const wrapperWithNoLocationInRouteProps = mount(
+    <LoginHandler
+      updateAuthenticationInfo={mockUpdateAuthenticationInfo}
+      {...routePropsNoLocation}
+    />
+  );
+
+  const wrapperWithNoHashInRouteProps = mount(
+    <LoginHandler
+      updateAuthenticationInfo={mockUpdateAuthenticationInfo}
+      {...routePropsNoHash}
+    />
+  );
+
+  const wrapperWithNoLwaResponseInRouteProps = mount(
+    <LoginHandler
+      updateAuthenticationInfo={mockUpdateAuthenticationInfo}
+      {...routePropsNoLwaResponse}
+    />
+  );
+
+  const wrappers = [
+    wrapperWithInvalidLwaResponse,
+    wrapperWithNoHashInRouteProps,
+    wrapperWithNoLocationInRouteProps,
+    wrapperWithNoLwaResponseInRouteProps,
+    wrapperWithNoRouteProps
+  ];
+
+  expect(mockUpdateAuthenticationInfo).not.toHaveBeenCalled();
+
+  wrappers.map(wrapper => wrapper.unmount());
+});

--- a/src/components/LoginHandler/__snapshots__/LoginHandler.test.js.snap
+++ b/src/components/LoginHandler/__snapshots__/LoginHandler.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders LoginHandler without crashing 1`] = `<LoginHandler />`;

--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { Route, Switch } from "react-router-dom";
+import LoginHandler from "LoginHandler/LoginHandler";
+import DefaultRedirect from "DefaultRedirect/DefaultRedirect";
+
+export default function Routes(props) {
+  return (
+    <Switch>
+      <Route
+        exact
+        path="/authresponse"
+        render={routeProps => <LoginHandler {...routeProps} {...props} />}
+      />
+      // TODO: Redirect to NotFound Page for other paths rather than redirecting
+      // to home. https://github.com/s-maheshbabu/silent-alexa/issues/55
+      <Route
+        exact
+        path="*"
+        render={routeProps => <DefaultRedirect {...routeProps} />}
+      />
+    </Switch>
+  );
+}

--- a/src/components/Routes/Routes.test.js
+++ b/src/components/Routes/Routes.test.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import Routes from "./Routes";
+import { MemoryRouter, Router } from "react-router-dom";
+import LoginHandler from "LoginHandler/LoginHandler";
+import DefaultRedirect from "../DefaultRedirect/DefaultRedirect";
+import { wrap } from "module";
+
+let loginHandler;
+let loginHandlerInstance;
+const mockUpdateAuthenticationInfo = jest.fn();
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+it("renders Routes with 2 redirects if path is /authresponse", () => {
+  const wrapper = mount(
+    <MemoryRouter initialEntries={["/authresponse"]}>
+      <Routes />
+    </MemoryRouter>
+  );
+  expect(wrapper.find(DefaultRedirect)).toHaveLength(1);
+  expect(
+    wrapper.find(DefaultRedirect).props("history").history.entries
+  ).toHaveLength(3);
+  wrapper.unmount();
+});
+
+it("renders Routes with 1 redirect if path is not /authresponse", () => {
+  const wrapper = mount(
+    <MemoryRouter initialEntries={["/anyOther"]}>
+      <Routes />
+    </MemoryRouter>
+  );
+  expect(wrapper.find(DefaultRedirect)).toHaveLength(1);
+  expect(
+    wrapper.find(DefaultRedirect).props("history").history.entries
+  ).toHaveLength(2);
+  wrapper.unmount();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "index.css";
 import App from "App/App";
+import { BrowserRouter as Router } from "react-router-dom";
 import registerServiceWorker from "registerServiceWorker";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+ReactDOM.render(
+  <Router>
+    <App />
+  </Router>,
+  document.getElementById("root")
+);
 registerServiceWorker();


### PR DESCRIPTION
Also, disabled the pop-up during login, so the user is redirected to hosted path with authentication_info in the query string on successful login of the user.

Also, with the current Routing constraints(passing the updateAuthenticationInfo prop to the redirect_uri), I couldnt figure out a way to redirect unregistered paths to "Page Not Found". Created an issue to look into it later. https://github.com/s-maheshbabu/silent-alexa/issues/55