### PR TITLE
Ignore all directives that are not 'Speak' directives.

### DIFF
--- a/src/avs/SpeakDirectiveParser.js
+++ b/src/avs/SpeakDirectiveParser.js
@@ -65,8 +65,8 @@ export function extractAlexaTextResponses(alexaRawResponse) {
     }
 
     _validateDirective(avsDirective);
-    // Directives that are not Speak directives (for ex, ExpectSpeech** directive) will be skipped for now. If and when we
-    // start supporting voice, non-Speak directives should also be handled.
+    // Directives that are not Speak directives (for ex, ExpectSpeech** directive) will be skipped for now. Tracking
+    // item to handle ExpectSpeech directives - https://github.com/s-maheshbabu/silent-alexa/issues/62
     // ** https://developer.amazon.com/docs/alexa-voice-service/speechrecognizer.html#expectspeech
     if (!_isSpeakDirective(avsDirective)) {
       console.log(

--- a/src/avs/SpeakDirectiveParser.js
+++ b/src/avs/SpeakDirectiveParser.js
@@ -7,8 +7,9 @@ import httpMessageParser from "http-message-parser";
 const TEXT_PART_CONTENT_TYPE = `application/json; charset=UTF-8`;
 /**
  * This method parses the multi-part AVS responses and extracts the
- * strings representing Alexa's responses. It strips away other information
- * like binary audio data, ssml tags etc.
+ * strings representing Alexa's responses from 'Speak' directives.
+ * It strips away other information like binary audio data, ssml
+ * tags etc in the 'Speak' directives.
  *
  * @param {String} alexaRawResponse The multi-part response from AVS. This
  * should not be empty or undefined.
@@ -63,14 +64,38 @@ export function extractAlexaTextResponses(alexaRawResponse) {
       );
     }
 
+    _validateDirective(avsDirective);
+    // Directives that are not Speak directives (for ex, ExpectSpeech** directive) will be skipped for now. If and when we
+    // start supporting voice, non-Speak directives should also be handled.
+    // ** https://developer.amazon.com/docs/alexa-voice-service/speechrecognizer.html#expectspeech
+    if (!_isSpeakDirective(avsDirective)) {
+      console.log(
+        "A non-Speak directive was encountered. Skipping the directive. " +
+          util.inspect(avsDirective, { showHidden: true, depth: null })
+      );
+      continue;
+    }
+
     if (!hasIn(avsDirective, ["directive", "payload", "caption"]))
       throw new IllegalArgumentError(
-        "Given directive doesn't contain the expected path directive.payload.caption. Input: " +
-          avsDirective
+        "Given Speak directive doesn't contain the expected path directive.payload.caption. Input: " +
+          `${util.inspect(avsDirective, { showHidden: true, depth: null })}`
       );
 
     alexaResponses.push(avsDirective.directive.payload.caption);
   }
 
   return fromJS(alexaResponses);
+}
+
+function _validateDirective(avsDirective) {
+  if (!hasIn(avsDirective, ["directive", "header", "name"]))
+    throw new IllegalArgumentError(
+      "Given directive doesn't declare a type at directive.header.name. Input: " +
+        `${util.inspect(avsDirective, { showHidden: true, depth: null })}`
+    );
+}
+
+function _isSpeakDirective(avsDirective) {
+  return avsDirective.directive.header.name === "Speak";
 }

--- a/src/avs/SpeakDirectiveParser.test.js
+++ b/src/avs/SpeakDirectiveParser.test.js
@@ -43,6 +43,18 @@ it("handles the invalid case where the directive in the AVS response is well for
   );
 });
 
+it("handles the invalid case where the directive in the AVS response is well formatted json but doesn't contain the 'header' key.", () => {
+  testIllegalArgumentHandling(
+    testData.header_key_doesnt_exist_in_avs_directive.rawData
+  );
+});
+
+it("handles the invalid case where the directive in the AVS response is well formatted json but doesn't contain the 'name' key.", () => {
+  testIllegalArgumentHandling(
+    testData.name_key_doesnt_exist_in_avs_directive.rawData
+  );
+});
+
 it("does not include non-text parts in Alexa's response", () => {
   const testObject = testData.multi_part_with_different_content_types;
 
@@ -52,6 +64,13 @@ it("does not include non-text parts in Alexa's response", () => {
 
 it("handles the case where Alexa's text response is broken into more than one part", () => {
   const testObject = testData.multi_part_with_just_three_parts;
+
+  const alexaTextResponses = parser(testObject.rawData);
+  expect(alexaTextResponses).toEqual(testObject.alexaResponses);
+});
+
+it("handles the case where there are non-Speak directives.", () => {
+  const testObject = testData.non_speak_directives;
 
   const alexaTextResponses = parser(testObject.rawData);
   expect(alexaTextResponses).toEqual(testObject.alexaResponses);

--- a/src/avs/test-data/multipart-response-test-data.js
+++ b/src/avs/test-data/multipart-response-test-data.js
@@ -105,6 +105,44 @@ first-part-of-multi-part-message
   };
 }
 
+// Invalid case where the AVS directive is well formatted JSON but doesn't contain the 'header' key.
+{
+  const anyKeyThatIsNot_header = "notHeader";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"${anyKeyThatIsNot_header}":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"caption","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">caption</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+first-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.header_key_doesnt_exist_in_avs_directive = {
+    rawData: rawData
+  };
+}
+
+// Invalid case where the AVS directive is well formatted JSON but doesn't contain the 'name' key.
+{
+  const anyKeyThatIsNot_name = "notName";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","${anyKeyThatIsNot_name}":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"caption","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">caption</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+first-part-of-multi-part-message
+--------abcde123--`;
+
+  exports.name_key_doesnt_exist_in_avs_directive = {
+    rawData: rawData
+  };
+}
+
 // A multi-part message with multiple parts where one part is a valid text response from Alexa and others are either valid non-text responses or parts whose Content-Type is not known.
 {
   const validTextResponseContentType = "application/json; charset=UTF-8";
@@ -171,6 +209,32 @@ second-audio-part-of-multi-part-message
   exports.multi_part_with_just_three_parts = {
     rawData: rawData,
     alexaResponses: List.of(alexaResponseFirstPart, alexaResponseSecondPart)
+  };
+}
+
+// Happy case with a combination of Speak directive, a non-Speak directive and directive without a type (directive.header.name) defined directives
+{
+  const anyTypeThatIsNot_Speak = "notSpeak";
+
+  const alexaResponse = "alexa success response";
+  const rawData = String.raw`--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechRecognizer","name":"${anyTypeThatIsNot_Speak}","messageId":"c506fe5f-8296-4618-a52e-2045cb1a6bdd"},"payload":{"timeoutInMilliseconds":8000}}}
+--------abcde123
+Content-Type: application/json; charset=UTF-8
+
+{"directive":{"header":{"namespace":"SpeechSynthesizer","name":"Speak","messageId":"67ba4c5a-211e-4722-a53d-44c9728f5377"},"payload":{"caption":"${alexaResponse}","url":"cid:f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545","format":"AUDIO_MPEG","token":"amzn1.as-ct.v1.Domain:Application:Knowledge#ACRI#f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV","ssml":"<speak><prosody volume=\"x-loud\"><p xmlns:amazon=\"https://amazon.com/ssml/2017-01-01/\" xmlns:ivona=\"http://www.ivona.com/2009/12/ssml\">${alexaResponse}</p></prosody><metadata><promptMetadata><promptId>AnswerSsml</promptId><namespace>SmartDJ.MusicQA</namespace><locale>en_US</locale><overrideId>default</overrideId><variant>809dfcd2-2807-4eaf-93e9-1130c2db01fa</variant><condition/><weight>1</weight><stageVersion>Adm-20141203_202706-183</stageVersion></promptMetadata></metadata></speak>"}}}
+--------abcde123
+Content-ID: <f17ff476-0960-443d-9805-3f5d398a3c5d#TextClient:1.0/2018/03/10/09/e59eab82b4da42b684ea5ed33b1955a7/04:05::TNIH_2V.f7f5577a-9b52-41d4-a273-c0796379590fZXV_1490666545>
+Content-Type: application/octet-stream
+
+second-part-of-multi-part-message
+--------abcde123`;
+
+  exports.non_speak_directives = {
+    rawData: rawData,
+    alexaResponses: List.of(alexaResponse)
   };
 }
 


### PR DESCRIPTION
Alexa sends an 'ExpectSpeech' directive along with a 'Speak'
directive for multi-turn dialogs. The intent is to tell the
client to re-open the microphone stream.

Since Silent Alexa is a text based app, 'ExpectSpeech' directive
is not really relevant (may be we can show a visual indicator
that Alexa is expecting the user to say something but it is an
immediate requirement).

Instead of failing on unexpected directives, this change is to
ignore any directive other than the 'Speak' directive.

https://github.com/s-maheshbabu/silent-alexa/issues/57